### PR TITLE
Spacewarp fast rotation fix

### DIFF
--- a/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/Varyings.hlsl
+++ b/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/Varyings.hlsl
@@ -23,7 +23,7 @@ Varyings BuildVaryings(Attributes input)
     // Evaluate Vertex Graph
     VertexDescriptionInputs vertexDescriptionInputs = BuildVertexDescriptionInputs(input);
     VertexDescription vertexDescription = VertexDescriptionFunction(vertexDescriptionInputs);
-
+    
     // Assign modified vertex attributes
     input.positionOS = vertexDescription.Position;
     #if defined(VARYINGS_NEED_NORMAL_WS)
@@ -152,3 +152,4 @@ Varyings BuildVaryings(Attributes input)
 
     return output;
 }
+

--- a/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/Varyings.hlsl
+++ b/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/Varyings.hlsl
@@ -135,7 +135,9 @@ Varyings BuildVaryings(Attributes input)
         float3 effectivePositionOS = (hasDeformation ? input.uv4.xyz : input.positionOS.xyz);
         float3 previousWS = TransformPreviousObjectToWorld(effectivePositionOS);
 
-        if (!IsSmoothRotation(UNITY_MATRIX_PREV_M._11_21_31, UNITY_MATRIX_PREV_M._12_22_32, UNITY_MATRIX_M._11_21_31, UNITY_MATRIX_M._12_22_32))
+        float4x4 previousOTW = GetPrevObjectToWorldMatrix();
+        float4x4 currentOTW = GetObjectToWorldMatrix();
+        if (!IsSmoothRotation(previousOTW._11_21_31, previousOTW._12_22_32, currentOTW._11_21_31, currentOTW._12_22_32))
         {
             output.prevPositionCS = output.curPositionCS;
         }

--- a/com.unity.render-pipelines.universal/ShaderLibrary/OculusMotionVectorCore.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/OculusMotionVectorCore.hlsl
@@ -43,7 +43,9 @@ Varyings vert(Attributes input)
         float3 effectivePositionOS = (hasDeformation ? input.previousPositionOS : input.positionOS.xyz);
         float3 previousWS = TransformPreviousObjectToWorld(effectivePositionOS);
 
-        if (!IsSmoothRotation(UNITY_MATRIX_PREV_M._11_21_31, UNITY_MATRIX_PREV_M._12_22_32, UNITY_MATRIX_M._11_21_31, UNITY_MATRIX_M._12_22_32))
+        float4x4 previousOTW = GetPrevObjectToWorldMatrix();
+        float4x4 currentOTW = GetObjectToWorldMatrix();
+        if (!IsSmoothRotation(previousOTW._11_21_31, previousOTW._12_22_32, currentOTW._11_21_31, currentOTW._12_22_32))
         {
             output.prevPositionCS = output.curPositionCS;
         }


### PR DESCRIPTION
# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR. If you do add documentation, make sure to add the relevant Graphics Docs team member as a reviewer of the PR. If you are not sure which person to add, see the [Docs team contacts sheet](https://docs.google.com/spreadsheets/d/1rgUWWgwLFEHIQ3Rz-LnK6PAKmbM49DZZ9al4hvnztOo/edit#gid=1058860420).
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
Detecting fast rotating objects in the vertex shader to turn of space warp of the object automatically

---
### Testing status
Tested with an application that had a fast rotating object and also did a performance benchmark to test if this new logic would be costly (was not costly).

---
### Comments to reviewers
Notes for the reviewers you have assigned.
