### PR TITLE
Add motion vectors pass for opaque particles

### DIFF
--- a/com.unity.render-pipelines.universal/ShaderLibrary/OculusMotionVectorCore.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/OculusMotionVectorCore.hlsl
@@ -22,6 +22,23 @@ bool IsSmoothRotation(float3 prevAxis1, float3 prevAxis2, float3 currAxis1, floa
     return all(angleDot > angleThreshold);
 }
 
+// Best effort for particles, we'll just take into account the camera motion.
+Varyings vertParticles(Attributes input)
+{
+    Varyings output = (Varyings)0;
+    UNITY_SETUP_INSTANCE_ID(input);
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+    VertexPositionInputs vertexInput = GetVertexPositionInputs(input.positionOS.xyz);
+    output.positionCS = vertexInput.positionCS;
+
+    float3 curWS = TransformObjectToWorld(input.positionOS.xyz);
+    output.curPositionCS = TransformWorldToHClip(curWS);
+    output.prevPositionCS = TransformWorldToPrevHClip(curWS);
+
+    return output;
+}
+
 Varyings vert(Attributes input)
 {
     Varyings output = (Varyings)0;

--- a/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesLit.shader
+++ b/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesLit.shader
@@ -355,6 +355,23 @@ Shader "Universal Render Pipeline/Particles/Lit"
             #include "Packages/com.unity.render-pipelines.universal/Shaders/Utils/Universal2D.hlsl"
             ENDHLSL
         }
+        Pass
+        {
+            Name "MotionVectors"
+            Tags{ "LightMode" = "MotionVectors"}
+            Tags { "RenderType" = "Opaque" }
+
+            ZWrite[_ZWrite]
+            Cull[_Cull]
+
+            HLSLPROGRAM
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/OculusMotionVectorCore.hlsl"
+
+            #pragma vertex vertParticles
+            #pragma fragment frag
+
+            ENDHLSL
+        }
     }
 
     Fallback "Universal Render Pipeline/Particles/Simple Lit"

--- a/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesSimpleLit.shader
+++ b/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesSimpleLit.shader
@@ -350,6 +350,23 @@ Shader "Universal Render Pipeline/Particles/Simple Lit"
             #include "Packages/com.unity.render-pipelines.universal/Shaders/Utils/Universal2D.hlsl"
             ENDHLSL
         }
+        Pass
+        {
+            Name "MotionVectors"
+            Tags{ "LightMode" = "MotionVectors"}
+            Tags { "RenderType" = "Opaque" }
+
+            ZWrite[_ZWrite]
+            Cull[_Cull]
+
+            HLSLPROGRAM
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/OculusMotionVectorCore.hlsl"
+
+            #pragma vertex vertParticles
+            #pragma fragment frag
+
+            ENDHLSL
+        }
     }
 
     Fallback "Universal Render Pipeline/Particles/Unlit"

--- a/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesUnlit.shader
+++ b/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesUnlit.shader
@@ -243,6 +243,23 @@ Shader "Universal Render Pipeline/Particles/Unlit"
 
             ENDHLSL
         }
+        Pass
+        {
+            Name "MotionVectors"
+            Tags{ "LightMode" = "MotionVectors"}
+            Tags { "RenderType" = "Opaque" }
+
+            ZWrite[_ZWrite]
+            Cull[_Cull]
+
+            HLSLPROGRAM
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/OculusMotionVectorCore.hlsl"
+
+            #pragma vertex vertParticles
+            #pragma fragment frag
+
+            ENDHLSL
+        }
     }
     CustomEditor "UnityEditor.Rendering.Universal.ShaderGUI.ParticlesUnlitShader"
 }


### PR DESCRIPTION
# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR. If you do add documentation, make sure to add the relevant Graphics Docs team member as a reviewer of the PR. If you are not sure which person to add, see the [Docs team contacts sheet](https://docs.google.com/spreadsheets/d/1rgUWWgwLFEHIQ3Rz-LnK6PAKmbM49DZZ9al4hvnztOo/edit#gid=1058860420).
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
Add a simple motion vectors pass for opaque particles to use with application space warp. We're only using the camera motion and not the motion of the particles themselves as an approximation for now.

---
### Testing status
Tested in an application with opaque and transparent particles with application space warp enabled and verified that we were writing the camera motion to the color buffer and the depth of the particles in the depth buffer of the motion vector pass (and only for opaque particles).

---
### Comments to reviewers
Notes for the reviewers you have assigned.
