### PR TITLE
Fix null reference exception that causes Shader Graph errors 

### DIFF
--- a/com.unity.render-pipelines.universal/Editor/ShaderGraph/Targets/UniversalTarget.cs
+++ b/com.unity.render-pipelines.universal/Editor/ShaderGraph/Targets/UniversalTarget.cs
@@ -902,6 +902,8 @@ namespace UnityEditor.Rendering.Universal.ShaderGraph
                 renderStates = CoreRenderStates.Default,
                 pragmas = CorePragmas.DOTSInstanced,
                 includes = CoreIncludes.MotionVectors,
+                defines = new DefineCollection(),
+                keywords = new KeywordCollection(),
             };
 
             AddAlphaClipControlToPass(ref result, target);


### PR DESCRIPTION
### Purpose of this PR
Fields `defines` and `keywords` are not initialized in the `MotionVector` pass descriptor constructor in `UniversalTarget.cs`. 
This causes null reference exceptions in Shader Graph under certain conditions (for example, when alpha clipping is enabled in the shader).

As a result, shaders that match these conditions will not be able to be shown in the Unity editor, or compiled at build time.

Note that these fields are initialized in every other pass descriptor. 

This fix initializes the two fields, which removes the associated exceptions, and allows the shader to be built properly.

---
### Testing status
Importing a shadergraph shader that has alpha clipping (e.g. from another project) will result in only a pink material visible in editor in the Oculus-VR fork of the Universal RP branch. The shader will not be viewable or editable in Shader Graph - double clicking it will launch a blank window and show an exception. The material will also show up as pink in device builds.

After applying this fix, we verified that the materials in question display as intended in the editor and in builds, and the Shader Graph editor window will display correctly. (Note: the fix will not take effect until you reimport the offending shaders)