### PR TITLE
AppSW MotionVector Improvements

### DIFF
--- a/Packages/com.unity.render-pipelines.universal/Editor/Debug.meta
+++ b/Packages/com.unity.render-pipelines.universal/Editor/Debug.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4f06321421d2f7a42af4c226d8395e59
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.render-pipelines.universal/Editor/Debug/OculusMotionVectorDebugShader.shader
+++ b/Packages/com.unity.render-pipelines.universal/Editor/Debug/OculusMotionVectorDebugShader.shader
@@ -1,0 +1,72 @@
+Shader "Unlit/OculusMotionVectorDebugShader"
+{
+    Properties
+    {
+        _MainTex ("Texture", 2DArray) = "white" {}
+        _MinValue ("Min Value", Float) = 0
+        _MaxValue ("Max Value", Float) = 1
+        [Toggle] _OnlyRed ("Only Red", Float) = 0
+    }
+    SubShader
+    {
+        Tags { "RenderType"="Opaque" }
+        LOD 100
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #pragma require 2darray
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            UNITY_DECLARE_TEX2DARRAY(_MainTex);
+
+            float _MinValue;
+            float _MaxValue;
+            float _OnlyRed;
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = float2(v.uv.x, 1 - v.uv.y);
+                return o;
+            }
+
+            float3 inv_lerp(const float from, const float to, const float3 value){
+              return (value - from) / (to - from);
+            }
+
+            fixed4 frag (v2f i) : SV_Target
+            {
+                // sample the texture
+                float3 col = UNITY_SAMPLE_TEX2DARRAY(_MainTex, float3(i.uv, 0)).rgb;
+
+                if (_OnlyRed == 1.0)
+                {
+                    col.gb = col.rr;
+                }
+
+                // Map to the specified range
+                col = inv_lerp(_MinValue, _MaxValue, col);
+
+                return float4(col, 1);
+            }
+            ENDCG
+        }
+    }
+}

--- a/Packages/com.unity.render-pipelines.universal/Editor/Debug/OculusMotionVectorDebugShader.shader.meta
+++ b/Packages/com.unity.render-pipelines.universal/Editor/Debug/OculusMotionVectorDebugShader.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 28c37e9a1009104429adb673051c63bf
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.render-pipelines.universal/Editor/Debug/OculusMotionVectorWindow.cs
+++ b/Packages/com.unity.render-pipelines.universal/Editor/Debug/OculusMotionVectorWindow.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using UnityEngine;
+using UnityEditor;
+using UnityEngine.Rendering;
+
+public class OculusMotionVectorWindow : EditorWindow {
+
+    private const int k_MotionVectorTextureSize = 512;
+
+    private Material m_DebugMotionVectorMaterial;
+    private Material m_DebugDepthMaterial;
+
+    private float m_MaxVectorValue = 0.1f;
+    private float m_MaxDepth = 0.01f;
+
+    [MenuItem ("Oculus/Debug Motion Vectors")]
+    public static void  ShowWindow ()
+    {
+        EditorWindow.GetWindow(typeof(OculusMotionVectorWindow));
+    }
+
+    private Material GetNamedMaterial(string name) {
+        var shaderGuid = AssetDatabase.FindAssets($"t:Shader {name}").FirstOrDefault();
+
+        return shaderGuid != null ? new Material(AssetDatabase.LoadAssetAtPath<Shader>(AssetDatabase.GUIDToAssetPath(shaderGuid))) : null;
+    }
+
+    private void InitMotionVectors() {
+
+        if (UnityEngine.Rendering.Universal.DebugOculusMotionVectorSettings.motionVectorRenderTarget == null)
+        {
+            UnityEngine.Rendering.Universal.DebugOculusMotionVectorSettings.motionVectorRenderTargetDesc = new RenderTextureDescriptor(k_MotionVectorTextureSize, k_MotionVectorTextureSize, RenderTextureFormat.ARGBFloat, 0) { vrUsage = VRTextureUsage.TwoEyes, dimension = TextureDimension.Tex2DArray, volumeDepth = 2 };
+            UnityEngine.Rendering.Universal.DebugOculusMotionVectorSettings.motionVectorRenderTarget = new RenderTexture(UnityEngine.Rendering.Universal.DebugOculusMotionVectorSettings.motionVectorRenderTargetDesc);
+        }
+
+        if (UnityEngine.Rendering.Universal.DebugOculusMotionVectorSettings.depthRenderTarget == null)
+        {
+            UnityEngine.Rendering.Universal.DebugOculusMotionVectorSettings.depthRenderTargetDesc = new RenderTextureDescriptor(k_MotionVectorTextureSize, k_MotionVectorTextureSize, RenderTextureFormat.Depth, 24) { vrUsage = VRTextureUsage.TwoEyes, dimension = TextureDimension.Tex2DArray, volumeDepth = 2 };
+            UnityEngine.Rendering.Universal.DebugOculusMotionVectorSettings.depthRenderTarget = new RenderTexture(UnityEngine.Rendering.Universal.DebugOculusMotionVectorSettings.depthRenderTargetDesc);
+        }
+    }
+
+    private void Awake() {
+
+        InitMotionVectors();
+        m_DebugMotionVectorMaterial = GetNamedMaterial("OculusMotionVectorDebugShader");
+        m_DebugMotionVectorMaterial.SetFloat("_OnlyRed", 0.0f);
+        m_DebugDepthMaterial = GetNamedMaterial("OculusMotionVectorDebugShader");
+        m_DebugDepthMaterial.SetFloat("_OnlyRed", 1.0f);
+    }
+
+    private void OnDestroy() {
+
+        DestroyImmediate(m_DebugMotionVectorMaterial);
+    }
+
+    void Update() {
+
+        Repaint();
+    }
+
+    void OnGUI () {
+
+        InitMotionVectors();
+        if (m_DebugMotionVectorMaterial == null) {
+            Awake();
+        }
+
+        UnityEngine.Rendering.Universal.DebugOculusMotionVectorSettings.enableDebugMotionVectors =
+            EditorGUILayout.Toggle("Enable Motion Vectors",
+                UnityEngine.Rendering.Universal.DebugOculusMotionVectorSettings.enableDebugMotionVectors);
+
+        EditorGUILayout.BeginHorizontal();
+        EditorGUILayout.BeginVertical();
+
+        m_DebugMotionVectorMaterial.SetFloat("_MinValue", -m_MaxVectorValue);
+        m_DebugMotionVectorMaterial.SetFloat("_MaxValue", m_MaxVectorValue);
+        EditorGUI.DrawPreviewTexture(
+            EditorGUILayout.GetControlRect(false, GUILayout.Height(k_MotionVectorTextureSize), GUILayout.Width(k_MotionVectorTextureSize)),
+            UnityEngine.Rendering.Universal.DebugOculusMotionVectorSettings.motionVectorRenderTarget,
+            m_DebugMotionVectorMaterial);
+
+        m_MaxVectorValue = 1 / EditorGUILayout.Slider("Vector Scale", 1 / m_MaxVectorValue, 1, 100);
+        EditorGUILayout.EndVertical();
+
+        EditorGUILayout.BeginVertical();
+
+        m_DebugDepthMaterial.SetFloat("_MinValue", 0);
+        m_DebugDepthMaterial.SetFloat("_MaxValue", m_MaxDepth);
+
+        EditorGUI.DrawPreviewTexture(
+            EditorGUILayout.GetControlRect(false, GUILayout.Height(k_MotionVectorTextureSize), GUILayout.Width(k_MotionVectorTextureSize)),
+            UnityEngine.Rendering.Universal.DebugOculusMotionVectorSettings.depthRenderTarget,
+            m_DebugDepthMaterial);
+
+        m_MaxDepth = 1 / EditorGUILayout.Slider("Depth Scale", 1 / m_MaxDepth, 1, 100);
+        EditorGUILayout.EndVertical();
+        EditorGUILayout.EndHorizontal();
+
+    }
+}

--- a/Packages/com.unity.render-pipelines.universal/Editor/Debug/OculusMotionVectorWindow.cs.meta
+++ b/Packages/com.unity.render-pipelines.universal/Editor/Debug/OculusMotionVectorWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8a8f55013bf26ac4689abe1fead6ebda
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/OculusMotionVectors.hlsl
+++ b/Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/OculusMotionVectors.hlsl
@@ -15,6 +15,13 @@ half4 frag(PackedVaryings packedInput) : SV_TARGET
     Varyings unpacked = UnpackVaryings(packedInput);
     UNITY_SETUP_INSTANCE_ID(unpacked);
 
+    #if _ALPHATEST_ON
+        UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(unpacked);
+        SurfaceDescription surfaceDescription = BuildSurfaceDescription(unpacked);
+
+        clip(surfaceDescription.Alpha - surfaceDescription.AlphaClipThreshold);
+    #endif
+
     float3 screenPos = unpacked.curPositionCS.xyz / unpacked.curPositionCS.w;
     float3 screenPosPrev = unpacked.prevPositionCS.xyz / unpacked.prevPositionCS.w;
     half4 color = (1);

--- a/Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/Varyings.hlsl
+++ b/Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/Varyings.hlsl
@@ -10,15 +10,6 @@
     float3 _LightPosition;
 #endif
 
-#ifdef VARYINGS_NEED_PREVIOUS_POSITION_CS
-    bool IsSmoothRotation(float3 prevAxis1, float3 prevAxis2, float3 currAxis1, float3 currAxis2)
-    {
-        float angleThreshold = 0.984f; // cos(10 degrees)
-        float2 angleDot = float2(dot(normalize(prevAxis1), normalize(currAxis1)), dot(normalize(prevAxis2), normalize(currAxis2)));
-        return all(angleDot > angleThreshold);
-    }
-#endif
-
 #if defined(FEATURES_GRAPH_VERTEX)
 #if defined(HAVE_VFX_MODIFICATION)
 VertexDescription BuildVertexDescription(Attributes input, AttributesElement element)
@@ -43,6 +34,15 @@ VertexDescription BuildVertexDescription(Attributes input)
 }
 #endif
 #endif
+
+float3 TransformPrevWorldToObject(float3 positionWS)
+{
+    #if !defined(SHADER_STAGE_RAY_TRACING)
+    return mul(GetPrevWorldToObjectMatrix(), float4(positionWS, 1.0)).xyz;
+    #else
+    return (float3)0;
+    #endif
+}
 
 Varyings BuildVaryings(Attributes input)
 {
@@ -207,24 +207,18 @@ Varyings BuildVaryings(Attributes input)
 #ifdef VARYINGS_NEED_PREVIOUS_POSITION_CS
     if (unity_MotionVectorsParams.y == 0.0)
     {
-        output.prevPositionCS = float4(0.0, 0.0, 0.0, 1.0);
+        output.prevPositionCS = output.curPositionCS;
     }
     else
     {
         bool hasDeformation = unity_MotionVectorsParams.x > 0.0;
-        float3 effectivePositionOS = (hasDeformation ? input.uv4.xyz : input.positionOS.xyz);
-        float3 previousWS = TransformPreviousObjectToWorld(effectivePositionOS);
-
-        float4x4 previousOTW = GetPrevObjectToWorldMatrix();
-        float4x4 currentOTW = GetObjectToWorldMatrix();
-        if (!IsSmoothRotation(previousOTW._11_21_31, previousOTW._12_22_32, currentOTW._11_21_31, currentOTW._12_22_32))
-        {
-            output.prevPositionCS = output.curPositionCS;
-        }
-        else
-        {
-            output.prevPositionCS = TransformWorldToPrevHClip(previousWS);
-        }
+        // interpolate to our next deformed position
+        float3 effectivePositionOS = (hasDeformation ? (2.0 * input.positionOS.xyz - input.previousPositionOS) : input.positionOS.xyz);
+        // transform to our next world position
+        float3 nextWS = TransformObjectToWorld(TransformPrevWorldToObject(TransformObjectToWorld(effectivePositionOS)));
+        // interpolate back to our new 'previous' position
+        float3 previousWS = 2.0 * curWS - nextWS;
+        output.prevPositionCS = TransformWorldToPrevHClip(previousWS);
     }
 #endif
 

--- a/Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Targets/UniversalTarget.cs
+++ b/Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Targets/UniversalTarget.cs
@@ -892,6 +892,7 @@ namespace UnityEditor.Rendering.Universal.ShaderGraph
 
                 // Port Mask
                 validVertexBlocks = CoreBlockMasks.Vertex,
+                validPixelBlocks = CoreBlockMasks.FragmentAlphaOnly,
 
                 // Fields
                 structs = CoreStructCollections.Default,
@@ -899,7 +900,7 @@ namespace UnityEditor.Rendering.Universal.ShaderGraph
                 fieldDependencies = CoreFieldDependencies.Default,
 
                 // Conditional State
-                renderStates = CoreRenderStates.Default,
+                renderStates = CoreRenderStates.DepthNormalsOnly(target),
                 pragmas = CorePragmas.DOTSInstanced,
                 includes = CoreIncludes.MotionVectors,
                 defines = new DefineCollection(),
@@ -1509,11 +1510,11 @@ namespace UnityEditor.Rendering.Universal.ShaderGraph
         public static readonly IncludeCollection MotionVectors = new IncludeCollection
         {
             // Pre-graph
-            { CoreIncludes.CorePregraph },
-            { CoreIncludes.ShaderGraphPregraph },
+            { CorePregraph },
+            { ShaderGraphPregraph },
 
             // Post-graph
-            { CoreIncludes.CorePostgraph },
+            { CorePostgraph },
             { kMotionVectors, IncludeLocation.Postgraph },
         };
     }

--- a/Packages/com.unity.render-pipelines.universal/Runtime/Debug/DebugOculusMotionVectorSettings.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/Debug/DebugOculusMotionVectorSettings.cs
@@ -1,0 +1,22 @@
+#if UNITY_EDITOR && ENABLE_VR && ENABLE_XR_MODULE
+
+using System;
+using System.Collections.Generic;
+using UnityEngine.XR;
+
+	namespace UnityEngine.Rendering.Universal
+	{
+
+		public static class DebugOculusMotionVectorSettings
+		{
+			public static bool enableDebugMotionVectors;
+
+			public static RenderTexture motionVectorRenderTarget;
+        	public static RenderTextureDescriptor motionVectorRenderTargetDesc;
+            public static RenderTexture depthRenderTarget;
+            public static RenderTextureDescriptor depthRenderTargetDesc;
+		}
+
+}
+
+#endif

--- a/Packages/com.unity.render-pipelines.universal/Runtime/Debug/DebugOculusMotionVectorSettings.cs.meta
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/Debug/DebugOculusMotionVectorSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1fe7dc3f22f1c9046a29f72c2c05d2ad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.render-pipelines.universal/Runtime/XR/XRPass.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/XR/XRPass.cs
@@ -88,12 +88,15 @@ namespace UnityEngine.Rendering.Universal
         // Same but for motion vectors
         internal RenderTargetIdentifier motionVectorRenderTarget { get; private set; }
         internal RenderTextureDescriptor motionVectorRenderTargetDesc { get; private set; }
+        internal RenderTargetIdentifier depthRenderTarget { get; private set; }
+        internal RenderTextureDescriptor depthRenderTargetDesc { get; private set; }
 
         static   RenderTargetIdentifier  invalidRT = -1;
         internal bool                    renderTargetValid { get => renderTarget != invalidRT; }
         internal bool                    renderTargetIsRenderTexture { get; private set; }
         internal bool motionVectorRenderTargetValid { get => motionVectorRenderTarget != invalidRT; }
         internal bool motionVectorRenderTargetIsRenderTexture { get; private set; }
+        internal bool depthRenderTargetValid { get => depthRenderTarget != invalidRT; }
 
         internal bool isLateLatchEnabled { get; set; }
         internal bool canMarkLateLatch { get; set; }
@@ -240,18 +243,23 @@ namespace UnityEngine.Rendering.Universal
             if (xrRenderPass.hasMotionVectorPass)
             {
                 passInfo.motionVectorRenderTarget = new RenderTargetIdentifier(xrRenderPass.motionVectorRenderTarget, 0, CubemapFace.Unknown, -1);
-
-                RenderTextureDescriptor xrMotionVectorDesc = xrRenderPass.renderTargetDesc;
-                RenderTextureDescriptor rtMotionVectorDesc = new RenderTextureDescriptor(xrMotionVectorDesc.width, xrMotionVectorDesc.height, xrMotionVectorDesc.colorFormat, xrMotionVectorDesc.depthBufferBits, xrMotionVectorDesc.mipCount);
-                rtMotionVectorDesc.dimension = xrRenderPass.renderTargetDesc.dimension;
-                rtMotionVectorDesc.volumeDepth = xrRenderPass.renderTargetDesc.volumeDepth;
-                rtMotionVectorDesc.vrUsage = xrRenderPass.renderTargetDesc.vrUsage;
-                rtMotionVectorDesc.sRGB = xrRenderPass.renderTargetDesc.sRGB;
-                passInfo.motionVectorRenderTargetDesc = rtMotionVectorDesc;
+                passInfo.motionVectorRenderTargetDesc = xrRenderPass.motionVectorRenderTargetDesc;
+                passInfo.depthRenderTarget = -1;
 
                 Debug.Assert(passInfo.motionVectorRenderTargetValid, "Invalid motion vector render target from XRDisplaySubsystem!");
             }
+#if UNITY_EDITOR
+            if (DebugOculusMotionVectorSettings.enableDebugMotionVectors)
+            {
+                passInfo.motionVectorRenderTarget = new RenderTargetIdentifier(DebugOculusMotionVectorSettings.motionVectorRenderTarget, 0, CubemapFace.Unknown, -1);
+                passInfo.motionVectorRenderTargetDesc = DebugOculusMotionVectorSettings.motionVectorRenderTargetDesc;
 
+                passInfo.depthRenderTarget = new RenderTargetIdentifier(DebugOculusMotionVectorSettings.depthRenderTarget, 0, CubemapFace.Unknown, -1);
+                passInfo.depthRenderTargetDesc = DebugOculusMotionVectorSettings.depthRenderTargetDesc;
+
+                Debug.Assert(passInfo.motionVectorRenderTargetValid, "Invalid motion vector render target from XRDisplaySubsystem!");
+            }
+#endif
             return passInfo;
         }
 

--- a/Packages/com.unity.render-pipelines.universal/ShaderLibrary/OculusMotionVectorStatic.hlsl.meta
+++ b/Packages/com.unity.render-pipelines.universal/ShaderLibrary/OculusMotionVectorStatic.hlsl.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 2fa45f2e143f45643ad46f27edd80ecd
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Update OculusMotionVectorPass to support all renderers, added debug UI to see motion vector buffer in editor

# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR. If you do add documentation, make sure to add the relevant Graphics Docs team member as a reviewer of the PR. If you are not sure which person to add, see the [Docs team contacts sheet](https://docs.google.com/spreadsheets/d/1rgUWWgwLFEHIQ3Rz-LnK6PAKmbM49DZZ9al4hvnztOo/edit#gid=1058860420).
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?

- Enable Motion Vector generation for transparent objects using Alpha Clip
- Generate MotionVectors for static objects, such as terrain
- Change motion vectors to be forward predictions (better for AppSW, but limits use in other contexts)

---
### Testing status
Describe what manual/automated tests were performed for this PR

---
### Comments to reviewers
Notes for the reviewers you have assigned.
