### PR TITLE
[2022.3] Fix Deprecated API Warning

### DIFF
--- a/Packages/com.unity.render-pipelines.universal/Runtime/Passes/OculusMotionVectorPass.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/Passes/OculusMotionVectorPass.cs
@@ -14,8 +14,8 @@ namespace UnityEngine.Rendering.Universal.Internal
         FilteringSettings m_FilteringSettings;
         ProfilingSampler m_ProfilingSampler;
 
-        RenderTargetIdentifier motionVectorColorIdentifier;
-        RenderTargetIdentifier motionVectorDepthIdentifier;
+        RTHandle motionVectorColorHandle;
+        RTHandle motionVectorDepthHandle;
 
         public OculusMotionVectorPass(string profilerTag, bool opaque, RenderPassEvent evt, RenderQueueRange renderQueueRange, LayerMask layerMask, StencilState stencilState, int stencilReference)
         {
@@ -32,16 +32,16 @@ namespace UnityEngine.Rendering.Universal.Internal
         }
 
         public void Setup(
-            RenderTargetIdentifier motionVecColorIdentifier,
-            RenderTargetIdentifier motionVecDepthIdentifier)
+            RTHandle motionVecColorIdentifier,
+            RTHandle motionVecDepthIdentifier)
         {
-            this.motionVectorColorIdentifier = motionVecColorIdentifier;
-            this.motionVectorDepthIdentifier = motionVecDepthIdentifier;
+            this.motionVectorColorHandle = motionVecColorIdentifier;
+            this.motionVectorDepthHandle = motionVecDepthIdentifier;
         }
 
         public override void OnCameraSetup(CommandBuffer cmd, ref RenderingData renderingData)
         {
-            ConfigureTarget(motionVectorColorIdentifier, motionVectorDepthIdentifier);
+            ConfigureTarget(motionVectorColorHandle, motionVectorDepthHandle);
             ConfigureClear(ClearFlag.All, Color.black);
         }
 


### PR DESCRIPTION
# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR. If you do add documentation, make sure to add the relevant Graphics Docs team member as a reviewer of the PR. If you are not sure which person to add, see the [Docs team contacts sheet](https://docs.google.com/spreadsheets/d/1rgUWWgwLFEHIQ3Rz-LnK6PAKmbM49DZZ9al4hvnztOo/edit#gid=1058860420).
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?

Fix deprecated API warning by passing motion vector color and depth RTs as RTHandles instead of RenderTargetIdentifiers

---
### Testing status
Describe what manual/automated tests were performed for this PR

Built and ran on Quest with AppSW Enabled, verified MotionVectors were rendered as expected

---
### Comments to reviewers
Notes for the reviewers you have assigned.
