### PR TITLE
[2022.3][AppSW] Fix incorrect motionVector pass check

### DIFF
--- a/Packages/com.unity.render-pipelines.core/Runtime/XR/XRPass.cs
+++ b/Packages/com.unity.render-pipelines.core/Runtime/XR/XRPass.cs
@@ -9,11 +9,9 @@ namespace UnityEngine.Experimental.Rendering
     /// </summary>
     public struct XRPassCreateInfo
     {
-        public static RenderTargetIdentifier mvInvalidRT = -1;
-        public bool motionVectorRenderTargetValid { get => motionVectorRenderTarget != mvInvalidRT; }
-
         internal RenderTargetIdentifier renderTarget;
         internal RenderTextureDescriptor renderTargetDesc;
+        internal bool motionVectorRenderTargetValid;
         internal RenderTargetIdentifier motionVectorRenderTarget;
         internal RenderTextureDescriptor motionVectorRenderTargetDesc;
         internal ScriptableCullingParameters cullingParameters;
@@ -126,7 +124,7 @@ namespace UnityEngine.Experimental.Rendering
         /// <summary>
         //  Check if render target is valid
         /// <summary>
-        public bool motionVectorRenderTargetValid { get => motionVectorRenderTarget != XRPassCreateInfo.mvInvalidRT; }
+        public bool motionVectorRenderTargetValid { get; private set; }
 
         /// <summary>
         /// Destination render target descriptor
@@ -350,6 +348,7 @@ namespace UnityEngine.Experimental.Rendering
             multipassId = createInfo.multipassId;
             AssignCullingParams(createInfo.cullingPassId, createInfo.cullingParameters);
             renderTarget = new RenderTargetIdentifier(createInfo.renderTarget, 0, CubemapFace.Unknown, -1);
+            motionVectorRenderTargetValid = createInfo.motionVectorRenderTargetValid;
             motionVectorRenderTarget = new RenderTargetIdentifier(createInfo.motionVectorRenderTarget, 0, CubemapFace.Unknown, -1);
             renderTargetDesc = createInfo.renderTargetDesc;
             m_OcclusionMesh.SetMaterial(createInfo.occlusionMeshMaterial);


### PR DESCRIPTION

# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR. If you do add documentation, make sure to add the relevant Graphics Docs team member as a reviewer of the PR. If you are not sure which person to add, see the [Docs team contacts sheet](https://docs.google.com/spreadsheets/d/1rgUWWgwLFEHIQ3Rz-LnK6PAKmbM49DZZ9al4hvnztOo/edit#gid=1058860420).
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
Instead of checking whether the motionVectorRenderTarget is equal to -1, simply copy the 'hasMotionVectorPass' from the engine's XRRenderPass.

---
### Testing status
Confirmed that MotionVector pass executes when expected and is skipped when not expected

---
### Comments to reviewers
Notes for the reviewers you have assigned.
