### PR TITLE
Subpass changes

### DIFF
--- a/Packages/com.unity.render-pipelines.core/Runtime/Textures/RTHandle.cs
+++ b/Packages/com.unity.render-pipelines.core/Runtime/Textures/RTHandle.cs
@@ -175,7 +175,7 @@ namespace UnityEngine.Rendering
         {
             m_RT = rt;
             m_ExternalTexture = null;
-            m_NameID = new RenderTargetIdentifier(rt);
+            m_NameID = new RenderTargetIdentifier(rt, 0, CubemapFace.Unknown, -1);
         }
 
         internal void SetTexture(Texture tex)

--- a/Packages/com.unity.render-pipelines.universal/Editor/RendererFeatures/RenderObjectsPassFeatureEditor.cs
+++ b/Packages/com.unity.render-pipelines.universal/Editor/RendererFeatures/RenderObjectsPassFeatureEditor.cs
@@ -36,6 +36,7 @@ namespace UnityEditor.Experimental.Rendering.Universal
             public static GUIContent overrideDepth = new GUIContent("Depth", "Select this option to specify how this Renderer Feature affects or uses the values in the Depth buffer.");
             public static GUIContent writeDepth = new GUIContent("Write Depth", "Choose to write depth to the screen.");
             public static GUIContent depthState = new GUIContent("Depth Test", "Choose a new depth test function.");
+            public static GUIContent depthInput = new GUIContent("Depth Input", "Choose to bind depth as an input attachment.");
 
             //Camera Settings
             public static GUIContent overrideCamera = new GUIContent("Camera", "Override camera matrices. Toggling this setting will make camera use perspective projection.");
@@ -70,6 +71,7 @@ namespace UnityEditor.Experimental.Rendering.Universal
         private SerializedProperty m_OverrideDepth;
         private SerializedProperty m_WriteDepth;
         private SerializedProperty m_DepthState;
+        private SerializedProperty m_DepthInput;
         //Stencil props
         private SerializedProperty m_StencilSettings;
         //Caemra props
@@ -124,6 +126,7 @@ namespace UnityEditor.Experimental.Rendering.Universal
             m_OverrideDepth = property.FindPropertyRelative("overrideDepthState");
             m_WriteDepth = property.FindPropertyRelative("enableWrite");
             m_DepthState = property.FindPropertyRelative("depthCompareFunction");
+            m_DepthInput = property.FindPropertyRelative("depthInput");
 
             //Stencil
             m_StencilSettings = property.FindPropertyRelative("stencilSettings");
@@ -174,6 +177,7 @@ namespace UnityEditor.Experimental.Rendering.Universal
                 //Override material
                 DoMaterialOverride(ref rect);
                 rect.y += Styles.defaultLineSpace;
+
                 //Override depth
                 DoDepthOverride(ref rect);
                 rect.y += Styles.defaultLineSpace;
@@ -262,6 +266,8 @@ namespace UnityEditor.Experimental.Rendering.Universal
                 EditorGUI.indentLevel++;
                 //Write depth
                 EditorGUI.PropertyField(rect, m_WriteDepth, Styles.writeDepth);
+                rect.y += Styles.defaultLineSpace;
+                EditorGUI.PropertyField(rect, m_DepthInput, Styles.depthInput);
                 rect.y += Styles.defaultLineSpace;
                 //Depth testing options
                 EditorGUI.PropertyField(rect, m_DepthState, Styles.depthState);

--- a/Packages/com.unity.render-pipelines.universal/Runtime/NativeRenderPass.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/NativeRenderPass.cs
@@ -499,7 +499,7 @@ namespace UnityEngine.Rendering.Universal
                     {
                         context.EndSubPass();
                         if (PassHasInputAttachments(m_ActiveRenderPassQueue[currentPassIndex]))
-                            context.BeginSubPass(attachmentIndices, m_ActiveRenderPassQueue[currentPassIndex].m_InputAttachmentIndices, false, false);
+                            context.BeginSubPass(attachmentIndices, m_ActiveRenderPassQueue[currentPassIndex].m_InputAttachmentIndices, m_ActiveRenderPassQueue[currentPassIndex].depthAttachmentIndex != ScriptableRenderPass.NO_DEPTH_INPUT, false);
                         else
                             context.BeginSubPass(attachmentIndices);
 
@@ -508,7 +508,7 @@ namespace UnityEngine.Rendering.Universal
                     else if (PassHasInputAttachments(m_ActiveRenderPassQueue[currentPassIndex]))
                     {
                         context.EndSubPass();
-                        context.BeginSubPass(attachmentIndices, m_ActiveRenderPassQueue[currentPassIndex].m_InputAttachmentIndices);
+                        context.BeginSubPass(attachmentIndices, m_ActiveRenderPassQueue[currentPassIndex].m_InputAttachmentIndices, m_ActiveRenderPassQueue[currentPassIndex].depthAttachmentIndex != ScriptableRenderPass.NO_DEPTH_INPUT);
 
                         m_LastBeginSubpassPassIndex = currentPassIndex;
                     }

--- a/Packages/com.unity.render-pipelines.universal/Runtime/NativeRenderPass.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/NativeRenderPass.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using Unity.Collections;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Rendering;
-using static UnityEngine.GraphicsBuffer;
 
 namespace UnityEngine.Rendering.Universal
 {

--- a/Packages/com.unity.render-pipelines.universal/Runtime/NativeRenderPass.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/NativeRenderPass.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Mail;
 using Unity.Collections;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Rendering;
+using static UnityEngine.GraphicsBuffer;
 
 namespace UnityEngine.Rendering.Universal
 {
@@ -296,9 +298,19 @@ namespace UnityEngine.Rendering.Universal
 
                 m_RenderPassesAttachmentCount[currentPassHash] = 0;
 
-                UpdateFinalStoreActions(currentMergeablePasses, ref cameraData);
+                // UpdateFinalStoreActions(currentMergeablePasses, ref cameraData);  // This does not handle the store op correctly for subpass
+                m_FinalColorStoreAction[0] = RenderBufferStoreAction.DontCare;
+                m_FinalDepthStoreAction = RenderBufferStoreAction.DontCare;
 
+                int lastPassIdx = 0;
+                foreach (var passIdx in currentMergeablePasses)
+                {
+                    if (passIdx == -1)
+                        break;
+                    lastPassIdx = passIdx;
+                }
                 int currentAttachmentIdx = 0;
+
                 foreach (var passIdx in currentMergeablePasses)
                 {
                     if (passIdx == -1)
@@ -316,21 +328,25 @@ namespace UnityEngine.Rendering.Universal
                     RenderTargetIdentifier colorAttachmentTarget;
                     // We are not rendering to Backbuffer so we have the RT and the information with it
                     // while also creating a new RenderTargetIdentifier to ignore the current depth slice (which might get bypassed in XR setup eventually)
-                    if (new RenderTargetIdentifier(passColorAttachment.nameID, 0, depthSlice: 0) != BuiltinRenderTextureType.CameraTarget)
+                    if (new RenderTargetIdentifier(pass.colorAttachmentHandle.nameID, 0, depthSlice: 0) != BuiltinRenderTextureType.CameraTarget)
                     {
-                        currentAttachmentDescriptor = new AttachmentDescriptor(depthOnly ? passColorAttachment.rt.descriptor.depthStencilFormat : passColorAttachment.rt.descriptor.graphicsFormat);
-                        samples = passColorAttachment.rt.descriptor.msaaSamples;
-                        colorAttachmentTarget = passColorAttachment.nameID;
+                        currentAttachmentDescriptor = new AttachmentDescriptor(pass.colorAttachmentHandle.rt ?
+                            depthOnly ? pass.colorAttachmentHandle.rt.descriptor.depthStencilFormat :
+                                        pass.colorAttachmentHandle.rt.descriptor.graphicsFormat:
+                            UniversalRenderPipeline.MakeRenderTextureGraphicsFormat(cameraData.isHdrEnabled, cameraData.hdrColorBufferPrecision, Graphics.preserveFramebufferAlpha)
+                            );
+                        samples = pass.colorAttachmentHandle.rt ?  pass.colorAttachmentHandle.rt.descriptor.msaaSamples: cameraData.cameraTargetDescriptor.msaaSamples;
+                        colorAttachmentTarget = pass.overrideCameraTarget ? pass.colorAttachmentHandle : m_CameraColorTarget.handle;
                     }
                     else // In this case we might be rendering the the targetTexture or the Backbuffer, so less information is available
                     {
                         currentAttachmentDescriptor = new AttachmentDescriptor(pass.renderTargetFormat[0] != GraphicsFormat.None ? pass.renderTargetFormat[0] : UniversalRenderPipeline.MakeRenderTextureGraphicsFormat(cameraData.isHdrEnabled, cameraData.hdrColorBufferPrecision, Graphics.preserveFramebufferAlpha));
-
                         samples = cameraData.cameraTargetDescriptor.msaaSamples;
-                        colorAttachmentTarget = usesTargetTexture ? new RenderTargetIdentifier(cameraData.targetTexture) : BuiltinRenderTextureType.CameraTarget;
+                        colorAttachmentTarget = usesTargetTexture ? new RenderTargetIdentifier(cameraData.targetTexture) : pass.overrideCameraTarget ? pass.colorAttachmentHandles[0] : m_CameraColorTarget.handle; // BuiltinRenderTextureType.CameraTarget;
                     }
 
                     currentAttachmentDescriptor.ConfigureTarget(colorAttachmentTarget, ((uint)finalClearFlag & (uint)ClearFlag.Color) == 0, true);
+
 
                     if (PassHasInputAttachments(pass))
                         SetupInputAttachmentIndices(pass);
@@ -351,18 +367,49 @@ namespace UnityEngine.Rendering.Universal
                     }
 
                     // resolving to the implicit color target's resolve surface TODO: handle m_CameraResolveTarget if present?
-                    if (samples > 1)
+#if UNITY_ANDROID && !UNITY_EDITOR
+                    bool lastSubpass = passIdx == lastPassIdx;
+#else
+                    bool lastSubpass = true;
+#endif
+                    // Update the final store opeartion, but only store at the last subpass if one subpass use store
+                    if (m_FinalDepthStoreAction == RenderBufferStoreAction.DontCare || pass.overriddenDepthStoreAction)
                     {
-                        currentAttachmentDescriptor.ConfigureResolveTarget(colorAttachmentTarget);
-                        if (RenderingUtils.MultisampleDepthResolveSupported())
-                            m_ActiveDepthAttachmentDescriptor.ConfigureResolveTarget(m_ActiveDepthAttachmentDescriptor.loadStoreTarget);
+                        m_FinalDepthStoreAction = pass.depthStoreAction;
                     }
 
+                    if ((m_FinalColorStoreAction[0] == RenderBufferStoreAction.DontCare || pass.overriddenColorStoreActions[0]) && pass.colorStoreActions.Length > 0)
+                        m_FinalColorStoreAction[0] = pass.colorStoreActions[0];
 
-                    if (m_UseOptimizedStoreActions)
+                    if (lastSubpass)
                     {
-                        currentAttachmentDescriptor.storeAction = m_FinalColorStoreAction[0];
+                        if (samples > 1)
+                        {
+                            if (m_FinalColorStoreAction[0] != RenderBufferStoreAction.DontCare)
+                            {
+                                currentAttachmentDescriptor.ConfigureResolveTarget(colorAttachmentTarget);
+                                currentAttachmentDescriptor.storeAction = RenderBufferStoreAction.Resolve;
+                            }
+
+                            if (m_FinalDepthStoreAction != RenderBufferStoreAction.DontCare)
+                            {
+                                if (RenderingUtils.MultisampleDepthResolveSupported())
+                                {
+                                    m_ActiveDepthAttachmentDescriptor.ConfigureResolveTarget(m_ActiveDepthAttachmentDescriptor.loadStoreTarget);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            currentAttachmentDescriptor.storeAction = RenderBufferStoreAction.Store;
+                        }
                         m_ActiveDepthAttachmentDescriptor.storeAction = m_FinalDepthStoreAction;
+                    }
+                    else
+                    {
+                        // Dont care if this is not the last subpass
+                        currentAttachmentDescriptor.storeAction = RenderBufferStoreAction.DontCare;
+                        m_ActiveDepthAttachmentDescriptor.storeAction = RenderBufferStoreAction.DontCare;
                     }
 
                     int existingAttachmentIndex = FindAttachmentDescriptorIndexInList(currentAttachmentIdx,
@@ -378,8 +425,9 @@ namespace UnityEngine.Rendering.Universal
                     }
                     else
                     {
-                        // attachment was already present
+                        // attachment was already present, update it according to the last subpass that uses it
                         pass.m_ColorAttachmentIndices[0] = existingAttachmentIndex;
+                        m_ActiveColorAttachmentDescriptors[existingAttachmentIndex] = currentAttachmentDescriptor;
                     }
                 }
             }
@@ -398,14 +446,23 @@ namespace UnityEngine.Rendering.Universal
                 var depthOnly = (renderPass.colorAttachmentHandle.rt != null && IsDepthOnlyRenderTexture(renderPass.colorAttachmentHandle.rt)) || (cameraData.targetTexture != null && IsDepthOnlyRenderTexture(cameraData.targetTexture));
                 bool useDepth = depthOnly || (!renderPass.overrideCameraTarget || (renderPass.overrideCameraTarget && renderPass.depthAttachmentHandle.nameID != BuiltinRenderTextureType.CameraTarget));// &&
 
-                var attachments =
-                    new NativeArray<AttachmentDescriptor>(useDepth && !depthOnly ? validColorBuffersCount + 1 : 1, Allocator.Temp);
+                int attachmentLen = depthOnly ? 1 : (useDepth ? validColorBuffersCount + 1 : validColorBuffersCount);
+                var attachments = new NativeArray<AttachmentDescriptor>(attachmentLen, Allocator.Temp);
 
                 for (int i = 0; i < validColorBuffersCount; ++i)
                     attachments[i] = m_ActiveColorAttachmentDescriptors[i];
 
                 if (useDepth && !depthOnly)
                     attachments[validColorBuffersCount] = m_ActiveDepthAttachmentDescriptor;
+
+
+                // Here we know the depth attachment, bind it to the input if the renderpass needs it
+                {
+                    if (PassHasInputAttachments(renderPass) && renderPass.bindCurrentDepthBuffer != -1 && renderPass.m_InputAttachmentIndices.Length > renderPass.bindCurrentDepthBuffer)
+                    {
+                        renderPass.m_InputAttachmentIndices[renderPass.bindCurrentDepthBuffer] = validColorBuffersCount;
+                    }
+                }
 
                 var rpDesc = InitializeRenderPassDescriptor(ref cameraData, renderPass);
 
@@ -444,7 +501,7 @@ namespace UnityEngine.Rendering.Universal
                     {
                         context.EndSubPass();
                         if (PassHasInputAttachments(m_ActiveRenderPassQueue[currentPassIndex]))
-                            context.BeginSubPass(attachmentIndices, m_ActiveRenderPassQueue[currentPassIndex].m_InputAttachmentIndices);
+                            context.BeginSubPass(attachmentIndices, m_ActiveRenderPassQueue[currentPassIndex].m_InputAttachmentIndices, false, false);
                         else
                             context.BeginSubPass(attachmentIndices);
 
@@ -494,7 +551,11 @@ namespace UnityEngine.Rendering.Universal
                 pass.m_InputAttachmentIndices[i] = FindAttachmentDescriptorIndexInList(pass.m_InputAttachments[i], m_ActiveColorAttachmentDescriptors);
                 if (pass.m_InputAttachmentIndices[i] == -1)
                 {
-                    Debug.LogWarning("RenderPass Input attachment not found in the current RenderPass");
+                    // Check if we are binding the depth buffer, but we don't know th depth attachment index yet
+                    if (pass.bindCurrentDepthBuffer != i)
+                    {
+                        Debug.LogWarning("RenderPass Input attachment not found in the current RenderPass");
+                    }
                     continue;
                 }
 
@@ -676,7 +737,8 @@ namespace UnityEngine.Rendering.Universal
         {
             GetRenderTextureDescriptor(ref cameraData, renderPass, out RenderTextureDescriptor targetRT);
 
-            var depthTarget = renderPass.overrideCameraTarget ? renderPass.depthAttachmentHandle : cameraDepthTargetHandle;
+            // Only use renderPass.depthAttachmentHandle if the renderPass does not set bindCurrentDepthBuffer, since post process pass does not actually care the depth buffer
+            var depthTarget = renderPass.overrideCameraTarget && renderPass.bindCurrentDepthBuffer == -1 ? renderPass.depthAttachmentHandle : cameraDepthTargetHandle;
             var depthID = (targetRT.graphicsFormat == GraphicsFormat.None && targetRT.depthStencilFormat != GraphicsFormat.None) ? renderPass.colorAttachmentHandle.GetHashCode() : depthTarget.GetHashCode();
 
             return new RenderPassDescriptor(targetRT.width, targetRT.height, targetRT.msaaSamples, depthID);

--- a/Packages/com.unity.render-pipelines.universal/Runtime/NativeRenderPass.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/NativeRenderPass.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Mail;
 using Unity.Collections;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Rendering;
@@ -458,9 +457,9 @@ namespace UnityEngine.Rendering.Universal
 
                 // Here we know the depth attachment, bind it to the input if the renderpass needs it
                 {
-                    if (PassHasInputAttachments(renderPass) && renderPass.bindCurrentDepthBuffer != -1 && renderPass.m_InputAttachmentIndices.Length > renderPass.bindCurrentDepthBuffer)
+                    if (PassHasInputAttachments(renderPass) && renderPass.depthAttachmentIndex != ScriptableRenderPass.NO_DEPTH_INPUT && renderPass.m_InputAttachmentIndices.Length > renderPass.depthAttachmentIndex)
                     {
-                        renderPass.m_InputAttachmentIndices[renderPass.bindCurrentDepthBuffer] = validColorBuffersCount;
+                        renderPass.m_InputAttachmentIndices[renderPass.depthAttachmentIndex] = validColorBuffersCount;
                     }
                 }
 
@@ -551,8 +550,8 @@ namespace UnityEngine.Rendering.Universal
                 pass.m_InputAttachmentIndices[i] = FindAttachmentDescriptorIndexInList(pass.m_InputAttachments[i], m_ActiveColorAttachmentDescriptors);
                 if (pass.m_InputAttachmentIndices[i] == -1)
                 {
-                    // Check if we are binding the depth buffer, but we don't know th depth attachment index yet
-                    if (pass.bindCurrentDepthBuffer != i)
+                    // Check if we are binding the depth buffer, but we don't know the depth attachment index yet
+                    if (pass.depthAttachmentIndex != i)
                     {
                         Debug.LogWarning("RenderPass Input attachment not found in the current RenderPass");
                     }
@@ -737,8 +736,8 @@ namespace UnityEngine.Rendering.Universal
         {
             GetRenderTextureDescriptor(ref cameraData, renderPass, out RenderTextureDescriptor targetRT);
 
-            // Only use renderPass.depthAttachmentHandle if the renderPass does not set bindCurrentDepthBuffer, since post process pass does not actually care the depth buffer
-            var depthTarget = renderPass.overrideCameraTarget && renderPass.bindCurrentDepthBuffer == -1 ? renderPass.depthAttachmentHandle : cameraDepthTargetHandle;
+            // Only use renderPass.depthAttachmentHandle if the renderPass.bindCurrentDepthBuffer is false, since post process pass does not actually care the depth buffer
+            var depthTarget = renderPass.overrideCameraTarget && !renderPass.bindCurrentDepthBuffer ? renderPass.depthAttachmentHandle : cameraDepthTargetHandle;
             var depthID = (targetRT.graphicsFormat == GraphicsFormat.None && targetRT.depthStencilFormat != GraphicsFormat.None) ? renderPass.colorAttachmentHandle.GetHashCode() : depthTarget.GetHashCode();
 
             return new RenderPassDescriptor(targetRT.width, targetRT.height, targetRT.msaaSamples, depthID);

--- a/Packages/com.unity.render-pipelines.universal/Runtime/Passes/FinalBlitPass.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/Passes/FinalBlitPass.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.CompilerServices;
 using UnityEngine.Experimental.Rendering.RenderGraphModule;
 
 namespace UnityEngine.Rendering.Universal.Internal

--- a/Packages/com.unity.render-pipelines.universal/Runtime/Passes/FinalBlitPass.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/Passes/FinalBlitPass.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using UnityEngine.Experimental.Rendering.RenderGraphModule;
 
 namespace UnityEngine.Rendering.Universal.Internal
@@ -180,13 +181,13 @@ namespace UnityEngine.Rendering.Universal.Internal
                 }
                 else
                 {
-                    FinalBlitPass.ExecutePass(ref renderingData, m_PassData.blitMaterialData, cameraTargetHandle, m_Source);
+                    FinalBlitPass.ExecutePass(ref renderingData, m_PassData.blitMaterialData, cameraTargetHandle, m_Source, isNativeRenderPass);
                     cameraData.renderer.ConfigureCameraTarget(cameraTargetHandle, cameraTargetHandle);
                 }
             }
         }
 
-        private static void ExecutePass(ref RenderingData renderingData, in BlitMaterialData blitMaterialData, RTHandle cameraTarget, RTHandle source)
+        private static void ExecutePass(ref RenderingData renderingData, in BlitMaterialData blitMaterialData, RTHandle cameraTarget, RTHandle source, bool isNRP)
         {
             var cameraData = renderingData.cameraData;
             var cmd = renderingData.commandBuffer;
@@ -203,7 +204,7 @@ namespace UnityEngine.Rendering.Universal.Internal
 #endif
 
             int shaderPassIndex = source.rt?.filterMode == FilterMode.Bilinear ? blitMaterialData.bilinearSamplerPass : blitMaterialData.nearestSamplerPass;
-            RenderingUtils.FinalBlit(cmd, ref cameraData, source, cameraTarget, loadAction, RenderBufferStoreAction.Store, blitMaterialData.material, shaderPassIndex);
+            RenderingUtils.FinalBlit(cmd, ref cameraData, source, cameraTarget, loadAction, RenderBufferStoreAction.Store, blitMaterialData.material, shaderPassIndex, isNRP);
         }
 
         private class PassData
@@ -292,7 +293,7 @@ namespace UnityEngine.Rendering.Universal.Internal
                         Blitter.BlitTexture(context.cmd, sourceTex, viewportScale, data.blitMaterialData.material, shaderPassIndex);
                     }
                     else
-                        ExecutePass(ref data.renderingData, data.blitMaterialData, data.destination, data.source);
+                        ExecutePass(ref data.renderingData, data.blitMaterialData, data.destination, data.source, false);
                 });
             }
         }

--- a/Packages/com.unity.render-pipelines.universal/Runtime/Passes/PostProcessPass.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/Passes/PostProcessPass.cs
@@ -456,9 +456,6 @@ namespace UnityEngine.Rendering.Universal
                 }
                 
 #endif
-                // Setup other effects constants
-                // SetupLensDistortion(m_Materials.uber, isSceneViewCamera);
-                SetupChromaticAberration(m_Materials.uber);
                 SetupVignette(m_Materials.uber, cameraData.xr);
                 SetupColorGrading(cmd, ref renderingData, m_Materials.uber);
 

--- a/Packages/com.unity.render-pipelines.universal/Runtime/Passes/RenderObjectsPass.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/Passes/RenderObjectsPass.cs
@@ -17,6 +17,9 @@ namespace UnityEngine.Experimental.Rendering.Universal
         string m_ProfilerTag;
         ProfilingSampler m_ProfilingSampler;
 
+        private const string DEPTH_INPUT_ATTACHMENT = "_DEPTH_INPUT_ATTACHMENT";
+        private static GlobalKeyword m_depthInputKeyword;
+
         /// <summary>
         /// The override material to use.
         /// </summary>
@@ -76,6 +79,13 @@ namespace UnityEngine.Experimental.Rendering.Universal
 
         RenderStateBlock m_RenderStateBlock;
 
+        [RuntimeInitializeOnLoadMethod]
+        private static void Initialize()
+        {
+            m_depthInputKeyword = GlobalKeyword.Create(DEPTH_INPUT_ATTACHMENT);
+        }
+
+
         /// <summary>
         /// The constructor for render objects pass.
         /// </summary>
@@ -126,16 +136,18 @@ namespace UnityEngine.Experimental.Rendering.Universal
 
         public override void OnCameraSetup(CommandBuffer cmd, ref RenderingData renderingData)
         {
+#if !UNITY_EDITOR
             ref CameraData cameraData = ref renderingData.cameraData;
             ref ScriptableRenderer renderer = ref cameraData.renderer;
 
             bindCurrentDepthBuffer = useDepthInputAttachment;
-
+            Shader.SetKeyword(m_depthInputKeyword, useDepthInputAttachment);
             if (useDepthInputAttachment)
-            {
+            {   
                 ConfigureInputAttachments(renderingData.cameraData.renderer.cameraDepthTargetHandle);
                 depthAttachmentIndex = 0;
             }
+#endif
         }
 
         /// <inheritdoc/>

--- a/Packages/com.unity.render-pipelines.universal/Runtime/Passes/RenderObjectsPass.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/Passes/RenderObjectsPass.cs
@@ -37,6 +37,8 @@ namespace UnityEngine.Experimental.Rendering.Universal
         /// </summary>
         public int overrideShaderPassIndex { get; set; }
 
+        public bool useDepthInputAttachment { get; set; } = false;
+
         List<ShaderTagId> m_ShaderTagIdList = new List<ShaderTagId>();
 
         /// <summary>
@@ -120,6 +122,20 @@ namespace UnityEngine.Experimental.Rendering.Universal
             : this(profileId.GetType().Name, renderPassEvent, shaderTags, renderQueueType, layerMask, cameraSettings)
         {
             m_ProfilingSampler = ProfilingSampler.Get(profileId);
+        }
+
+        public override void OnCameraSetup(CommandBuffer cmd, ref RenderingData renderingData)
+        {
+            ref CameraData cameraData = ref renderingData.cameraData;
+            ref ScriptableRenderer renderer = ref cameraData.renderer;
+
+            bindCurrentDepthBuffer = useDepthInputAttachment;
+
+            if (useDepthInputAttachment)
+            {
+                ConfigureInputAttachments(renderingData.cameraData.renderer.cameraDepthTargetHandle);
+                depthAttachmentIndex = 0;
+            }
         }
 
         /// <inheritdoc/>

--- a/Packages/com.unity.render-pipelines.universal/Runtime/Passes/ScriptableRenderPass.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/Passes/ScriptableRenderPass.cs
@@ -306,6 +306,7 @@ namespace UnityEngine.Rendering.Universal
         internal bool isBlitRenderPass { get; set; }
 
         internal bool useNativeRenderPass { get; set; }
+        internal bool isNativeRenderPass = false; // To avoid Y-flip when NRP is used but the pass does not support NRP.
 
         // index to track the position in the current frame
         internal int renderPassQueueIndex { get; set; }
@@ -319,6 +320,8 @@ namespace UnityEngine.Rendering.Universal
         RTHandle[] m_ColorAttachments;
         RenderTargetIdentifier[] m_ColorAttachmentIds;
         internal RTHandle[] m_InputAttachments = new RTHandle[8];
+        internal int bindCurrentDepthBuffer = -1; // When setting up the pass, bind the current in use depth buffer.
+
         internal bool[] m_InputAttachmentIsTransient = new bool[8];
         RTHandle m_DepthAttachment;
         RenderTargetIdentifier m_DepthAttachmentId;

--- a/Packages/com.unity.render-pipelines.universal/Runtime/Passes/ScriptableRenderPass.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/Passes/ScriptableRenderPass.cs
@@ -320,7 +320,11 @@ namespace UnityEngine.Rendering.Universal
         RTHandle[] m_ColorAttachments;
         RenderTargetIdentifier[] m_ColorAttachmentIds;
         internal RTHandle[] m_InputAttachments = new RTHandle[8];
-        internal int bindCurrentDepthBuffer = -1; // When setting up the pass, bind the current in use depth buffer.
+
+        public const int NO_DEPTH_INPUT = -1;
+        internal bool bindCurrentDepthBuffer = false; // When setting up the pass, bind the current in used depth buffer so the subpass will be merged.
+        internal int depthAttachmentIndex = NO_DEPTH_INPUT; // Bind the current in used depth buffer to this index inside render pass.
+
 
         internal bool[] m_InputAttachmentIsTransient = new bool[8];
         RTHandle m_DepthAttachment;

--- a/Packages/com.unity.render-pipelines.universal/Runtime/PostProcessPasses.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/PostProcessPasses.cs
@@ -62,7 +62,7 @@ namespace UnityEngine.Rendering.Universal
         /// </summary>
         /// <param name="rendererPostProcessData">Post process resources.</param>
         /// <param name="postProcessParams">Post process run-time creation parameters.</param>
-        public PostProcessPasses(PostProcessData rendererPostProcessData, ref PostProcessParams postProcessParams)
+        public PostProcessPasses(PostProcessData rendererPostProcessData, ref PostProcessParams postProcessParams, bool useNativeRenderPass = false)
         {
             m_ColorGradingLutPass = null;
             m_PostProcessPass = null;
@@ -74,7 +74,7 @@ namespace UnityEngine.Rendering.Universal
 
             m_RendererPostProcessData = rendererPostProcessData;
             m_BlitMaterial = postProcessParams.blitMaterial;
-            Recreate(rendererPostProcessData, ref postProcessParams);
+            Recreate(rendererPostProcessData, ref postProcessParams, useNativeRenderPass);
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace UnityEngine.Rendering.Universal
         /// </summary>
         /// <param name="data">Resources used for creating passes. In case of the null, no passes will be created.</param>
         /// <param name="ppParams">Run-time parameters used for creating passes.</param>
-        public void Recreate(PostProcessData data, ref PostProcessParams ppParams)
+        public void Recreate(PostProcessData data, ref PostProcessParams ppParams, bool useNativeRenderPass=false)
         {
             if (m_RendererPostProcessData)
                 data = m_RendererPostProcessData;
@@ -106,8 +106,8 @@ namespace UnityEngine.Rendering.Universal
             if (data != null)
             {
                 m_ColorGradingLutPass = new ColorGradingLutPass(RenderPassEvent.BeforeRenderingPrePasses, data);
-                m_PostProcessPass = new PostProcessPass(RenderPassEvent.BeforeRenderingPostProcessing, data, ref ppParams);
-                m_FinalPostProcessPass = new PostProcessPass(RenderPassEvent.AfterRenderingPostProcessing, data, ref ppParams);
+                m_PostProcessPass = new PostProcessPass(RenderPassEvent.BeforeRenderingPostProcessing, data, ref ppParams, useNativeRenderPass);
+                m_FinalPostProcessPass = new PostProcessPass(RenderPassEvent.AfterRenderingPostProcessing, data, ref ppParams, useNativeRenderPass);
                 m_CurrentPostProcessData = data;
             }
         }

--- a/Packages/com.unity.render-pipelines.universal/Runtime/RenderTargetBufferSystem.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/RenderTargetBufferSystem.cs
@@ -79,6 +79,7 @@ namespace UnityEngine.Rendering.Universal.Internal
                 RenderingUtils.ReAllocateIfNeeded(ref m_B.rtMSAA, desc, m_FilterMode, TextureWrapMode.Clamp, name: m_B.name);
 
             desc.msaaSamples = 1;
+            desc.bindMS = false; // For resolve texture
             RenderingUtils.ReAllocateIfNeeded(ref m_A.rtResolve, desc, m_FilterMode, TextureWrapMode.Clamp, name: m_A.name);
             RenderingUtils.ReAllocateIfNeeded(ref m_B.rtResolve, desc, m_FilterMode, TextureWrapMode.Clamp, name: m_B.name);
             cmd.SetGlobalTexture(m_A.name, m_A.rtResolve);
@@ -101,7 +102,12 @@ namespace UnityEngine.Rendering.Universal.Internal
             m_B.msaa = m_Desc.msaaSamples;
 
             if (m_Desc.msaaSamples > 1)
+            {
                 EnableMSAA(true);
+#if UNITY_ANDROID && !UNITY_EDITOR
+                m_Desc.bindMS = true; // Allow we bind this render target as MS
+#endif
+            }
         }
 
         public RTHandle GetBufferA()

--- a/Packages/com.unity.render-pipelines.universal/Runtime/RendererFeatures/RenderObjects.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/RendererFeatures/RenderObjects.cs
@@ -119,6 +119,11 @@ namespace UnityEngine.Experimental.Rendering.Universal
             /// The camera settings to use.
             /// </summary>
             public CustomCameraSettings cameraSettings = new CustomCameraSettings();
+
+             /// <summary>
+             /// Sets whether it should has depth as input attachment or not.
+             /// </summary>
+             public bool depthInput = false;
         }
 
         /// <summary>
@@ -223,7 +228,10 @@ namespace UnityEngine.Experimental.Rendering.Universal
             }
 
             if (settings.overrideDepthState)
+            {
+                renderObjectsPass.useDepthInputAttachment = settings.depthInput;
                 renderObjectsPass.SetDetphState(settings.enableWrite, settings.depthCompareFunction);
+            }
 
             if (settings.stencilSettings.overrideStencilState)
                 renderObjectsPass.SetStencilState(settings.stencilSettings.stencilReference,

--- a/Packages/com.unity.render-pipelines.universal/Runtime/RenderingUtils.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/RenderingUtils.cs
@@ -202,7 +202,8 @@ namespace UnityEngine.Rendering.Universal
             RTHandle destination,
             RenderBufferLoadAction loadAction,
             RenderBufferStoreAction storeAction,
-            Material material, int passIndex)
+            Material material, int passIndex,
+            bool isNRP = false)
         {
             bool isRenderToBackBufferTarget = !cameraData.isSceneViewCamera;
 #if ENABLE_VR && ENABLE_XR_MODULE
@@ -215,7 +216,7 @@ namespace UnityEngine.Rendering.Universal
             // We y-flip if
             // 1) we are blitting from render texture to back buffer(UV starts at bottom) and
             // 2) renderTexture starts UV at top
-            bool yflip = isRenderToBackBufferTarget && cameraData.targetTexture == null && SystemInfo.graphicsUVStartsAtTop;
+            bool yflip = isRenderToBackBufferTarget && cameraData.targetTexture == null && SystemInfo.graphicsUVStartsAtTop && !isNRP;
             Vector4 scaleBias = yflip ? new Vector4(viewportScale.x, -viewportScale.y, 0, viewportScale.y) : new Vector4(viewportScale.x, viewportScale.y, 0, 0);
             CoreUtils.SetRenderTarget(cmd, destination, loadAction, storeAction, ClearFlag.None, Color.clear);
             if (isRenderToBackBufferTarget)

--- a/Packages/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
@@ -212,8 +212,6 @@ namespace UnityEngine.Rendering.Universal
             {
                 cameraWidth = (float)cameraData.cameraTargetDescriptor.width;
                 cameraHeight = (float)cameraData.cameraTargetDescriptor.height;
-
-                useRenderPassEnabled = false;
             }
 
             if (camera.allowDynamicResolution)
@@ -1504,6 +1502,7 @@ namespace UnityEngine.Rendering.Universal
                 ExecuteNativeRenderPass(context, renderPass, ref cameraData, ref renderingData); // cmdBuffer is executed inside
             else
             {
+                renderPass.isNativeRenderPass = useRenderPassEnabled;
                 renderPass.Execute(context, ref renderingData);
                 context.ExecuteCommandBuffer(cmd);
                 cmd.Clear();
@@ -1783,8 +1782,9 @@ namespace UnityEngine.Rendering.Universal
                         {
                             // SetRenderTarget might alter the internal device state(winding order).
                             // Non-stereo buffer is already updated internally when switching render target. We update stereo buffers here to keep the consistency.
-                            bool renderIntoTexture = passColorAttachment.nameID != cameraData.xr.renderTarget;
+                            bool renderIntoTexture = passColorAttachment.nameID != cameraData.xr.renderTarget && !useRenderPassEnabled; // Prevent Unity from flipping the v coord of the texture.
                             cameraData.PushBuiltinShaderConstantsXR(cmd, renderIntoTexture);
+
                             XRSystemUniversal.MarkShaderProperties(cmd, cameraData.xrUniversal, renderIntoTexture);
                         }
 #endif

--- a/Packages/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
@@ -1782,7 +1782,7 @@ namespace UnityEngine.Rendering.Universal
                         {
                             // SetRenderTarget might alter the internal device state(winding order).
                             // Non-stereo buffer is already updated internally when switching render target. We update stereo buffers here to keep the consistency.
-                            bool renderIntoTexture = passColorAttachment.nameID != cameraData.xr.renderTarget && !useRenderPassEnabled; // Prevent Unity from flipping the v coord of the texture.
+                            bool renderIntoTexture = passColorAttachment.nameID != cameraData.xr.renderTarget && !useRenderPassEnabled; // Prevent Unity from flipping the y coord of the texture.
                             cameraData.PushBuiltinShaderConstantsXR(cmd, renderIntoTexture);
 
                             XRSystemUniversal.MarkShaderProperties(cmd, cameraData.xrUniversal, renderIntoTexture);

--- a/Packages/com.unity.render-pipelines.universal/Runtime/Unity.RenderPipelines.Universal.Runtime.asmdef
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/Unity.RenderPipelines.Universal.Runtime.asmdef
@@ -7,9 +7,7 @@
         "GUID:7dbf32976982c98448af054f2512cb79",
         "GUID:d8b63aba1907145bea998dd612889d6b",
         "GUID:2665a8d13d1b3f18800f46e256720795",
-		"GUID:86bc95e6fdb13ff43aa04316542905ae",
-        "Unity.XR.OpenXR",
-        "Unity.XR.Oculus"
+		"GUID:86bc95e6fdb13ff43aa04316542905ae"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -68,16 +66,6 @@
             "name": "com.unity.inputsystem",
             "expression": "0.0.0",
             "define": "ENABLE_INPUT_SYSTEM_PACKAGE"
-        },
-        {
-            "name": "com.unity.xr.oculus",
-            "expression": "",
-            "define": "USING_XR_SDK_OCULUS"
-        },
-        {
-            "name": "com.unity.xr.openxr",
-            "expression": "",
-            "define": "USING_XR_SDK_OPENXR"
         }
     ],
     "noEngineReferences": false

--- a/Packages/com.unity.render-pipelines.universal/Runtime/Unity.RenderPipelines.Universal.Runtime.asmdef
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/Unity.RenderPipelines.Universal.Runtime.asmdef
@@ -7,7 +7,9 @@
         "GUID:7dbf32976982c98448af054f2512cb79",
         "GUID:d8b63aba1907145bea998dd612889d6b",
         "GUID:2665a8d13d1b3f18800f46e256720795",
-		"GUID:86bc95e6fdb13ff43aa04316542905ae"
+		"GUID:86bc95e6fdb13ff43aa04316542905ae",
+        "Unity.XR.OpenXR",
+        "Unity.XR.Oculus"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -66,6 +68,16 @@
             "name": "com.unity.inputsystem",
             "expression": "0.0.0",
             "define": "ENABLE_INPUT_SYSTEM_PACKAGE"
+        },
+        {
+            "name": "com.unity.xr.oculus",
+            "expression": "",
+            "define": "USING_XR_SDK_OCULUS"
+        },
+        {
+            "name": "com.unity.xr.openxr",
+            "expression": "",
+            "define": "USING_XR_SDK_OPENXR"
         }
     ],
     "noEngineReferences": false

--- a/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
@@ -1124,6 +1124,15 @@ namespace UnityEngine.Rendering.Universal
         /// <summary> Keyword used for Multi Sampling Anti-Aliasing (MSAA) with 8 per pixel sample count. </summary>
         public const string DepthMsaa8 = "_DEPTH_MSAA_8";
 
+        /// <summary> Keyword used for Multi Sampling Anti-Aliasing (MSAA) with 2 per pixel sample count. </summary>
+        public const string Msaa2 = "_MSAA_2";
+
+        /// <summary> Keyword used for Multi Sampling Anti-Aliasing (MSAA) with 4 per pixel sample count. </summary>
+        public const string Msaa4 = "_MSAA_4";
+
+        /// <summary> Keyword used for Multi Sampling Anti-Aliasing (MSAA) with 8 per pixel sample count. </summary>
+        public const string Msaa8 = "_MSAA_8";
+
         /// <summary> Keyword used for Linear to SRGB conversions. </summary>
         public const string LinearToSRGBConversion = "_LINEAR_TO_SRGB_CONVERSION";
 

--- a/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRenderer.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRenderer.cs
@@ -1277,7 +1277,7 @@ namespace UnityEngine.Rendering.Universal
                     // active depth is depth target, we don't need a blit pass to resolve
                     bool depthTargetResolved = m_ActiveCameraDepthAttachment.nameID == cameraData.xr.renderTarget || applyPostProcessing;
 
-                    if (!depthTargetResolved && cameraData.xr.copyDepth)
+                    if (!depthTargetResolved && cameraData.xr.copyDepth && !useRenderPassEnabled)
                     {
                         m_XRCopyDepthPass.Setup(m_ActiveCameraDepthAttachment, m_XRTargetHandleAlias);
                         m_XRCopyDepthPass.CopyToDepth = true;

--- a/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRenderer.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRenderer.cs
@@ -315,7 +315,7 @@ namespace UnityEngine.Rendering.Universal
                 if (asset)
                     postProcessParams.requestHDRFormat = UniversalRenderPipeline.MakeRenderTextureGraphicsFormat(asset.supportsHDR, asset.hdrColorBufferPrecision, false);
 
-                m_PostProcessPasses = new PostProcessPasses(data.postProcessData, ref postProcessParams);
+                m_PostProcessPasses = new PostProcessPasses(data.postProcessData, ref postProcessParams, useRenderPassEnabled);
             }
 
             m_CapturePass = new CapturePass(RenderPassEvent.AfterRendering);
@@ -1188,7 +1188,7 @@ namespace UnityEngine.Rendering.Universal
                 m_RenderTransparentForwardPass.ConfigureDepthStoreAction(transparentPassDepthStoreAction);
                 EnqueuePass(m_RenderTransparentForwardPass);
             }
-            EnqueuePass(m_OnRenderObjectCallbackPass);
+            // EnqueuePass(m_OnRenderObjectCallbackPass);
 
             bool shouldRenderUI = cameraData.rendersOverlayUI;
             bool outputToHDR = cameraData.isHDROutputActive;
@@ -1275,7 +1275,7 @@ namespace UnityEngine.Rendering.Universal
                 if (cameraData.xr.enabled)
                 {
                     // active depth is depth target, we don't need a blit pass to resolve
-                    bool depthTargetResolved = m_ActiveCameraDepthAttachment.nameID == cameraData.xr.renderTarget;
+                    bool depthTargetResolved = m_ActiveCameraDepthAttachment.nameID == cameraData.xr.renderTarget || applyPostProcessing;
 
                     if (!depthTargetResolved && cameraData.xr.copyDepth)
                     {

--- a/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRenderer.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRenderer.cs
@@ -1188,6 +1188,8 @@ namespace UnityEngine.Rendering.Universal
                 m_RenderTransparentForwardPass.ConfigureDepthStoreAction(transparentPassDepthStoreAction);
                 EnqueuePass(m_RenderTransparentForwardPass);
             }
+
+            // Render object callback pass will prevent post-processing and draw object pass from merging.
             // EnqueuePass(m_OnRenderObjectCallbackPass);
 
             bool shouldRenderUI = cameraData.rendersOverlayUI;

--- a/Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderGraphFunctions.hlsl
+++ b/Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderGraphFunctions.hlsl
@@ -26,8 +26,18 @@
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DeclareNormalsTexture.hlsl"
 #endif
 
+
+#if defined(_DEPTH_INPUT_ATTACHMENT)
+    #define depth_input 0
+    FRAMEBUFFER_INPUT_FLOAT_MS(depth_input);
+#endif
+
 float shadergraph_LWSampleSceneDepth(float2 uv)
 {
+#if defined(_DEPTH_INPUT_ATTACHMENT)
+    return LOAD_FRAMEBUFFER_INPUT_MS(depth_input, 0, float2(0,0));
+#endif
+    
 #if defined(REQUIRE_DEPTH_TEXTURE)
     return SampleSceneDepth(uv);
 #else
@@ -36,7 +46,7 @@ float shadergraph_LWSampleSceneDepth(float2 uv)
 }
 
 float3 shadergraph_LWSampleSceneColor(float2 uv)
-{
+{    
 #if defined(REQUIRE_OPAQUE_TEXTURE)
     return SampleSceneColor(uv);
 #else


### PR DESCRIPTION
Enable vulkan subpass in Unity 2022.3, which makes post processing and depth input shaders to be merged into one single vulkan render pass.
# **Please read the [Contributing guide](CONTRIBUTING.md) before making a PR.**

* Read the [Graphics repository & Yamato FAQ](http://go/graphics-yamato-faq).

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR. If you do add documentation, make sure to add the relevant Graphics Docs team member as a reviewer of the PR. If you are not sure which person to add, see the [Docs team contacts sheet](https://docs.google.com/spreadsheets/d/1rgUWWgwLFEHIQ3Rz-LnK6PAKmbM49DZZ9al4hvnztOo/edit#gid=1058860420).
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?

---
### Testing status
Describe what manual/automated tests were performed for this PR

---
### Comments to reviewers
Notes for the reviewers you have assigned.
