### PR TITLE
Render graph subpass changes

### DIFF
--- a/Packages/com.unity.render-pipelines.core/Runtime/XR/XRSystem.cs
+++ b/Packages/com.unity.render-pipelines.core/Runtime/XR/XRSystem.cs
@@ -463,6 +463,7 @@ namespace UnityEngine.Experimental.Rendering
             rtDesc.volumeDepth  = xrDesc.volumeDepth;
             rtDesc.vrUsage      = xrDesc.vrUsage;
             rtDesc.sRGB         = xrDesc.sRGB;
+            rtDesc.msaaSamples  = xrDesc.msaaSamples;
             rtDesc.shadowSamplingMode = xrDesc.shadowSamplingMode;
             return rtDesc;
         }

--- a/Packages/com.unity.render-pipelines.universal/Editor/RendererFeatures/RenderObjectsPassFeatureEditor.cs
+++ b/Packages/com.unity.render-pipelines.universal/Editor/RendererFeatures/RenderObjectsPassFeatureEditor.cs
@@ -52,6 +52,7 @@ namespace UnityEditor.Experimental.Rendering.Universal
             public static GUIContent overrideDepth = new GUIContent("Depth", "Select this option to specify how this Renderer Feature affects or uses the values in the Depth buffer.");
             public static GUIContent writeDepth = new GUIContent("Write Depth", "Choose to write depth to the screen.");
             public static GUIContent depthState = new GUIContent("Depth Test", "Choose a new depth test function.");
+            public static GUIContent depthInput = new GUIContent("Depth Input", "Choose to bind depth as an input attachment.");
 
             //Camera Settings
             public static GUIContent overrideCamera = new GUIContent("Camera", "Override camera matrices. Toggling this setting will make camera use perspective projection.");
@@ -86,6 +87,7 @@ namespace UnityEditor.Experimental.Rendering.Universal
         private SerializedProperty m_OverrideDepth;
         private SerializedProperty m_WriteDepth;
         private SerializedProperty m_DepthState;
+        private SerializedProperty m_DepthInput;
         //Stencil props
         private SerializedProperty m_StencilSettings;
         //Caemra props
@@ -140,6 +142,7 @@ namespace UnityEditor.Experimental.Rendering.Universal
             m_OverrideDepth = property.FindPropertyRelative("overrideDepthState");
             m_WriteDepth = property.FindPropertyRelative("enableWrite");
             m_DepthState = property.FindPropertyRelative("depthCompareFunction");
+            m_DepthInput = property.FindPropertyRelative("depthInput");
 
             //Stencil
             m_StencilSettings = property.FindPropertyRelative("stencilSettings");
@@ -278,6 +281,13 @@ namespace UnityEditor.Experimental.Rendering.Universal
                 EditorGUI.indentLevel++;
                 //Write depth
                 EditorGUI.PropertyField(rect, m_WriteDepth, Styles.writeDepth);
+                rect.y += Styles.defaultLineSpace;
+                EditorGUI.PropertyField(rect, m_DepthInput, Styles.depthInput);
+                if (m_DepthInput.boolValue && m_WriteDepth.boolValue) {
+                    Debug.LogWarning("Depth Input and Write Depth can't be used at the same time. Uncheck Write Depth.");
+                    m_WriteDepth.boolValue = false;
+                }
+                
                 rect.y += Styles.defaultLineSpace;
                 //Depth testing options
                 EditorGUI.PropertyField(rect, m_DepthState, Styles.depthState);

--- a/Packages/com.unity.render-pipelines.universal/Editor/RendererFeatures/RenderObjectsPassFeatureEditor.cs
+++ b/Packages/com.unity.render-pipelines.universal/Editor/RendererFeatures/RenderObjectsPassFeatureEditor.cs
@@ -284,7 +284,7 @@ namespace UnityEditor.Experimental.Rendering.Universal
                 rect.y += Styles.defaultLineSpace;
                 EditorGUI.PropertyField(rect, m_DepthInput, Styles.depthInput);
                 if (m_DepthInput.boolValue && m_WriteDepth.boolValue) {
-                    Debug.LogWarning("Depth Input and Write Depth can't be used at the same time. Uncheck Write Depth.");
+                    Debug.LogWarning("Depth Input and Write Depth can't be used at the same time. Write Depth has been disabled.");
                     m_WriteDepth.boolValue = false;
                 }
                 

--- a/Packages/com.unity.render-pipelines.universal/Runtime/Passes/ColorGradingLutPass.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/Passes/ColorGradingLutPass.cs
@@ -133,7 +133,7 @@ namespace UnityEngine.Rendering.Universal.Internal
 #endif
 
             CoreUtils.SetRenderTarget(renderingData.commandBuffer, m_InternalLut, RenderBufferLoadAction.DontCare, RenderBufferStoreAction.Store, ClearFlag.None, Color.clear);
-            ExecutePass(CommandBufferHelpers.GetRasterCommandBuffer(renderingData.commandBuffer), m_PassData, m_InternalLut);
+            ExecutePass(CommandBufferHelpers.GetRasterCommandBuffer(renderingData.commandBuffer), m_PassData);
         }
 
         private class PassData
@@ -147,7 +147,7 @@ namespace UnityEngine.Rendering.Universal.Internal
             internal TextureHandle internalLut;
         }
 
-        private static void ExecutePass(RasterCommandBuffer cmd, PassData passData, RTHandle internalLutTarget)
+        private static void ExecutePass(RasterCommandBuffer cmd, PassData passData)
         {
             var lutBuilderLdr = passData.lutBuilderLdr;
             var lutBuilderHdr = passData.lutBuilderHdr;
@@ -269,7 +269,7 @@ namespace UnityEngine.Rendering.Universal.Internal
                 passData.cameraData.xr.StopSinglePass(cmd);
 
                 // Render the lut.
-                Blitter.BlitTexture(cmd, internalLutTarget, Vector2.one, material, 0);
+                Blitter.BlitTexture(cmd, Vector2.one, material, 0);
 
                 passData.cameraData.xr.StartSinglePass(cmd);
             }
@@ -299,7 +299,7 @@ namespace UnityEngine.Rendering.Universal.Internal
 
                 builder.SetRenderFunc((PassData data, RasterGraphContext context) =>
                 {
-                    ExecutePass(context.cmd, data, data.internalLut);
+                    ExecutePass(context.cmd, data);
                 });
 
                 return;

--- a/Packages/com.unity.render-pipelines.universal/Runtime/Passes/PostProcessPassRenderGraph.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/Passes/PostProcessPassRenderGraph.cs
@@ -1811,6 +1811,7 @@ namespace UnityEngine.Rendering.Universal
             internal bool isBackbuffer;
             internal bool enableAlphaOutput;
             internal bool hasFinalPass;
+            internal bool isPassMerged;
         }
 
         TextureHandle TryGetCachedUserLutTextureHandle(RenderGraph renderGraph)
@@ -1870,8 +1871,26 @@ namespace UnityEngine.Rendering.Universal
                 builder.AllowGlobalStateModification(true);
                 passData.destinationTexture = destTexture;
                 builder.SetRenderAttachment(destTexture, 0, AccessFlags.Write);
-                passData.sourceTexture = sourceTexture;
-                builder.UseTexture(sourceTexture, AccessFlags.Read);
+
+                bool tileCompatible = !(
+                    m_Bloom.IsActive() ||
+                    m_ChromaticAberration.IsActive() ||
+                    m_DepthOfField.IsActive() ||
+                    m_LensDistortion.IsActive() ||
+                    m_MotionBlur.IsActive() ||
+                    m_PaniniProjection.IsActive());
+                bool passMerged = SystemInfo.graphicsDeviceType == GraphicsDeviceType.Vulkan && tileCompatible;
+                   
+                
+                if (passMerged)
+                {
+                    builder.SetInputAttachment(sourceTexture, index: 0, AccessFlags.Read);
+                }
+                else
+                {
+                    passData.sourceTexture = sourceTexture;
+                    builder.UseTexture(sourceTexture, AccessFlags.Read);
+                }
                 passData.lutTexture = lutTexture;
                 builder.UseTexture(lutTexture, AccessFlags.Read);
                 passData.lutParams = lutParams;
@@ -1893,6 +1912,7 @@ namespace UnityEngine.Rendering.Universal
                 passData.isHdrGrading = hdrGrading;
                 passData.enableAlphaOutput = enableAlphaOutput;
                 passData.hasFinalPass = hasFinalPass;
+                passData.isPassMerged = passMerged; 
 
                 builder.SetRenderFunc(static (UberPostPassData data, RasterGraphContext context) =>
                 {
@@ -1922,8 +1942,42 @@ namespace UnityEngine.Rendering.Universal
 
                     CoreUtils.SetKeyword(material, ShaderKeywordStrings._ENABLE_ALPHA_OUTPUT, data.enableAlphaOutput);
 
+                    CoreUtils.SetKeyword(material, "SUBPASS_INPUT_ATTACHMENT", data.isPassMerged);
                     // Done with Uber, blit it
-                    ScaleViewportAndBlit(cmd, sourceTextureHdl, data.destinationTexture, data.cameraData, material, data.hasFinalPass);
+                    if (data.isPassMerged)
+                    {
+                        switch (data.cameraData.cameraTargetDescriptor.msaaSamples)
+                        {
+                            case 8:
+                                CoreUtils.SetKeyword(material, ShaderKeywordStrings.Msaa2, false);
+                                CoreUtils.SetKeyword(material, ShaderKeywordStrings.Msaa4, false);
+                                CoreUtils.SetKeyword(material, ShaderKeywordStrings.Msaa8, true);
+                                break;
+                            case 4:
+                                CoreUtils.SetKeyword(material, ShaderKeywordStrings.Msaa2, false);
+                                CoreUtils.SetKeyword(material, ShaderKeywordStrings.Msaa4, true);
+                                CoreUtils.SetKeyword(material, ShaderKeywordStrings.Msaa8, false);
+                                break;
+                            case 2:
+                                CoreUtils.SetKeyword(material, ShaderKeywordStrings.Msaa2, true);
+                                CoreUtils.SetKeyword(material, ShaderKeywordStrings.Msaa4, false);
+                                CoreUtils.SetKeyword(material, ShaderKeywordStrings.Msaa8, false);
+                                break;
+                            default:
+                                CoreUtils.SetKeyword(material, ShaderKeywordStrings.Msaa2, false);
+                                CoreUtils.SetKeyword(material, ShaderKeywordStrings.Msaa4, false);
+                                CoreUtils.SetKeyword(material, ShaderKeywordStrings.Msaa8, false);
+                                break;
+                        }
+
+
+                        Vector4 scaleBias = new Vector4(1, 1, 0, 0);
+                        Blitter.BlitTexture(cmd, scaleBias, material, 0);
+                    }
+                    else
+                    {
+                        ScaleViewportAndBlit(cmd, sourceTextureHdl, data.destinationTexture, data.cameraData, material, data.hasFinalPass);
+                    }
                 });
 
                 return;

--- a/Packages/com.unity.render-pipelines.universal/Runtime/RendererFeatures/RenderObjects.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/RendererFeatures/RenderObjects.cs
@@ -119,6 +119,11 @@ namespace UnityEngine.Rendering.Universal
             /// The camera settings to use.
             /// </summary>
             public CustomCameraSettings cameraSettings = new CustomCameraSettings();
+
+            /// <summary>
+            /// Sets whether it should has depth as input attachment or not.
+            /// </summary>
+            public bool depthInput = false;
         }
 
         /// <summary>
@@ -223,7 +228,10 @@ namespace UnityEngine.Rendering.Universal
             }
 
             if (settings.overrideDepthState)
+            {
+                renderObjectsPass.useDepthInputAttachment = settings.depthInput;
                 renderObjectsPass.SetDepthState(settings.enableWrite, settings.depthCompareFunction);
+            }
 
             if (settings.stencilSettings.overrideStencilState)
                 renderObjectsPass.SetStencilState(settings.stencilSettings.stencilReference,

--- a/Packages/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
@@ -923,7 +923,7 @@ namespace UnityEngine.Rendering.Universal
 
                 builder.SetRenderFunc((PassData data, RasterGraphContext context) =>
                 {
-                    bool yFlip = !SystemInfo.graphicsUVStartsAtTop || data.isTargetBackbuffer;
+                    bool yFlip = !SystemInfo.graphicsUVStartsAtTop || data.isTargetBackbuffer || (renderGraph.nativeRenderPassesEnabled && SystemInfo.graphicsDeviceType == GraphicsDeviceType.Vulkan);
 
                     // This is still required because of the following reasons:
                     // - Camera billboard properties.

--- a/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
@@ -1205,6 +1205,15 @@ namespace UnityEngine.Rendering.Universal
         /// <summary> Keyword used for Multi Sampling Anti-Aliasing (MSAA) with 8 per pixel sample count. </summary>
         public const string DepthMsaa8 = "_DEPTH_MSAA_8";
 
+        /// <summary> Keyword used for Multi Sampling Anti-Aliasing (MSAA) with 2 per pixel sample count. </summary>
+        public const string Msaa2 = "_MSAA_2";
+
+        /// <summary> Keyword used for Multi Sampling Anti-Aliasing (MSAA) with 4 per pixel sample count. </summary>
+        public const string Msaa4 = "_MSAA_4";
+
+        /// <summary> Keyword used for Multi Sampling Anti-Aliasing (MSAA) with 8 per pixel sample count. </summary>
+        public const string Msaa8 = "_MSAA_8";
+
         /// <summary> Keyword used for Linear to SRGB conversions. </summary>
         public const string LinearToSRGBConversion = "_LINEAR_TO_SRGB_CONVERSION";
 

--- a/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRenderer.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRenderer.cs
@@ -1873,7 +1873,9 @@ namespace UnityEngine.Rendering.Universal
             int msaaSamples = cameraTargetDescriptor.msaaSamples;
             bool isScaledRender = cameraData.imageScalingMode != ImageScalingMode.None;
             bool isCompatibleBackbufferTextureDimension = cameraTargetDescriptor.dimension == TextureDimension.Tex2D;
-            bool requiresExplicitMsaaResolve = msaaSamples > 1 && PlatformRequiresExplicitMsaaResolve();
+            // In XR when the eye buffer have msaa auto resolve (the render target has msaa samples > 1), we don't need an explicit resolve.
+            // This will avoid the finalBlit pass when using MSAA.
+            bool requiresExplicitMsaaResolve = msaaSamples > 1 && !(cameraData.xr.enabled && cameraData.xr.renderTargetDesc.msaaSamples > 1) && PlatformRequiresExplicitMsaaResolve();
             bool isOffscreenRender = cameraData.targetTexture != null && !isSceneViewCamera;
             bool isCapturing = cameraData.captureActions != null;
 

--- a/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRendererRenderGraph.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRendererRenderGraph.cs
@@ -297,7 +297,7 @@ namespace UnityEngine.Rendering.Universal
 
             useDepthPriming = IsDepthPrimingEnabled(cameraData);
 
-            if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Vulkan)
+            if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Vulkan && renderGraph.nativeRenderPassesEnabled)
             {
                 // With vulkan subpass, we expect no "yFlip" is needed, so we don't need color and depth to be the same
                 createDepthTexture = requireDepthTexture;

--- a/Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderGraphFunctions.hlsl
+++ b/Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderGraphFunctions.hlsl
@@ -26,8 +26,17 @@
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DeclareNormalsTexture.hlsl"
 #endif
 
+#if defined(_DEPTH_INPUT_ATTACHMENT)
+    #define depth_input 0
+    FRAMEBUFFER_INPUT_FLOAT_MS(depth_input);
+#endif
+
 float shadergraph_LWSampleSceneDepth(float2 uv)
 {
+#if defined(_DEPTH_INPUT_ATTACHMENT)
+    return LOAD_FRAMEBUFFER_INPUT_MS(depth_input, 0, float2(0,0));
+#endif
+ 
 #if defined(REQUIRE_DEPTH_TEXTURE)
     return SampleSceneDepth(uv);
 #else


### PR DESCRIPTION
Enable vulkan subpass in Unity 6.0, which makes post processing and depth input shaders to be merged into one single vulkan render pass. This works with Render Graph API.