### PR TITLE
Cherry pick of "Enable renderViewportScale for XR intermediate textures" to fix dynamic resolution in 14.0.8

### DIFF
--- a/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
@@ -906,11 +906,6 @@ namespace UnityEngine.Rendering.Universal
             baseCameraData.pixelHeight = (int)System.Math.Round(camPixelRect.height + camPixelRect.y) - (int)System.Math.Round(camPixelRect.y);
             baseCameraData.aspectRatio = (float)baseCameraData.pixelWidth / (float)baseCameraData.pixelHeight;
 
-            bool isDefaultXRViewport = (!(Math.Abs(xrViewport.x) > 0.0f || Math.Abs(xrViewport.y) > 0.0f ||
-                Math.Abs(xrViewport.width) < xr.renderTargetDesc.width ||
-                Math.Abs(xrViewport.height) < xr.renderTargetDesc.height));
-            baseCameraData.isDefaultViewport = baseCameraData.isDefaultViewport && isDefaultXRViewport;
-
             // Update cameraData cameraTargetDescriptor for XR. This descriptor is mainly used for configuring intermediate screen space textures
             var originalTargetDesc = baseCameraData.cameraTargetDescriptor;
             baseCameraData.cameraTargetDescriptor = xr.renderTargetDesc;
@@ -919,8 +914,24 @@ namespace UnityEngine.Rendering.Universal
                 baseCameraData.cameraTargetDescriptor.graphicsFormat = originalTargetDesc.graphicsFormat;
             }
             baseCameraData.cameraTargetDescriptor.msaaSamples = originalTargetDesc.msaaSamples;
-            baseCameraData.cameraTargetDescriptor.width = baseCameraData.pixelWidth;
-            baseCameraData.cameraTargetDescriptor.height = baseCameraData.pixelHeight;
+
+            if (baseCameraData.isDefaultViewport)
+            {
+                // When viewport is default, intermediate textures created with this descriptor will have dynamic resolution enabled.
+                baseCameraData.cameraTargetDescriptor.useDynamicScale = true;
+            }
+            else
+            {
+                // Some effects like Vignette computes aspect ratio from width and height. We have to take viewport into consideration if it is not default viewport.
+                baseCameraData.cameraTargetDescriptor.width = baseCameraData.pixelWidth;
+                baseCameraData.cameraTargetDescriptor.height = baseCameraData.pixelHeight;
+				baseCameraData.cameraTargetDescriptor.useDynamicScale = false;
+            }
+
+            bool isDefaultXRViewport = (!(Math.Abs(xrViewport.x) > 0.0f || Math.Abs(xrViewport.y) > 0.0f ||
+                Math.Abs(xrViewport.width) < xr.renderTargetDesc.width ||
+                Math.Abs(xrViewport.height) < xr.renderTargetDesc.height));
+            baseCameraData.isDefaultViewport = baseCameraData.isDefaultViewport && isDefaultXRViewport;
         }
 
         static void UpdateVolumeFramework(Camera camera, UniversalAdditionalCameraData additionalCameraData)


### PR DESCRIPTION
This change makes sure that tempRT are scaled correctly with Quest renderViewportScale feature without having to reallocate them.

Currently, changing XRSettings.renderViewportScale will trigger a reallocation of all tempRT since we modify the cameraTargetDescriptor width/height, which is used by render passes to configure their tempRT.

The fix avoids changing the value of cameraTargetDescriptor by using the full RT size as the width and height and enabling scaling of all render targets (using the ScalableBufferManager) that use the cameraTargetDescriptor.

Minor doc fixes.

---
### Purpose of this PR
This is a cherry pick of the fix landed in 14.0.9 that prevents dynamic resolution from reallocating the render targets on resize. We still recommend 14.0.8 for some 2022 users, so we want to fix it in 14.0.8 as well.

---
### Testing status
Tested with an app with dynamic resolution enabled. Worked as expected.
