### PR TITLE
[6000.0] Fixed Custom URP Compile errors, prepared for test project integration

### DIFF
--- a/Packages/com.unity.render-pipelines.core/Editor/Lighting/ProbeVolume/DynamicGI/DynamicGISkyOcclusion.urtshader.meta
+++ b/Packages/com.unity.render-pipelines.core/Editor/Lighting/ProbeVolume/DynamicGI/DynamicGISkyOcclusion.urtshader.meta
@@ -4,7 +4,7 @@ ScriptedImporter:
   internalIDToNameTable: []
   externalObjects: {}
   serializedVersion: 2
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
-  script: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: 42d537a8a4089e448a99fc57a06d74a9, type: 3}

--- a/Packages/com.unity.render-pipelines.core/Editor/Lighting/ProbeVolume/RenderingLayerMask/TraceRenderingLayerMask.urtshader.meta
+++ b/Packages/com.unity.render-pipelines.core/Editor/Lighting/ProbeVolume/RenderingLayerMask/TraceRenderingLayerMask.urtshader.meta
@@ -4,7 +4,7 @@ ScriptedImporter:
   internalIDToNameTable: []
   externalObjects: {}
   serializedVersion: 2
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
-  script: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: 42d537a8a4089e448a99fc57a06d74a9, type: 3}

--- a/Packages/com.unity.render-pipelines.core/Editor/Lighting/ProbeVolume/VirtualOffset/TraceVirtualOffset.urtshader
+++ b/Packages/com.unity.render-pipelines.core/Editor/Lighting/ProbeVolume/VirtualOffset/TraceVirtualOffset.urtshader
@@ -6,7 +6,7 @@
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Sampling/Sampling.hlsl"
 
 #include "Packages/com.unity.render-pipelines.core/Runtime/UnifiedRayTracing/FetchGeometry.hlsl"
-#include "Packages/com.unity.render-pipelines.core/Runtime/UnifiedRayTracing/TraceRayAndQueryHit.hlsl"
+#include "Packages/com.unity.render-pipelines.core/Runtime/UnifiedRayTracing/TraceRay.hlsl"
 
 
 #define DISTANCE_THRESHOLD 5e-5f

--- a/Packages/com.unity.render-pipelines.core/Editor/UnifiedRayTracing.meta
+++ b/Packages/com.unity.render-pipelines.core/Editor/UnifiedRayTracing.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e22e9a992c344981ad1bed28fc2a3cf5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/com.unity.render-pipelines.core/Editor/UnifiedRayTracing/UnifiedRTShaderImporter.cs
+++ b/Packages/com.unity.render-pipelines.core/Editor/UnifiedRayTracing/UnifiedRTShaderImporter.cs
@@ -1,0 +1,35 @@
+using UnityEditor.AssetImporters;
+using System.IO;
+
+namespace UnityEditor.Rendering.UnifiedRayTracing
+{
+    [ScriptedImporter(1, "urtshader")]
+    internal class UnifiedRTShaderImporter : ScriptedImporter
+    {
+        public override void OnImportAsset(AssetImportContext ctx)
+        {
+            string source = File.ReadAllText(ctx.assetPath);
+
+            var com = ShaderUtil.CreateComputeShaderAsset(ctx, computeShaderTemplate.Replace("SHADERCODE", source));
+            var rt = ShaderUtil.CreateRayTracingShaderAsset(ctx,
+                raytracingShaderTemplate.Replace("SHADERCODE", source));
+
+            ctx.AddObjectToAsset("ComputeShader", com);
+            ctx.AddObjectToAsset("RayTracingShader", rt);
+            ctx.SetMainObject(com);
+        }
+
+        // NOTE: The UnifiedRayTracing runtime was vendored into com.unity.render-pipelines.core
+        // (see "Move light transport package in urp"), so these raygen includes point at the
+        // vendored core location rather than the original com.unity.rendering.light-transport package.
+        const string computeShaderTemplate =
+            "#define UNIFIED_RT_BACKEND_COMPUTE\n" +
+            "SHADERCODE\n" +
+            "#include_with_pragmas \"Packages/com.unity.render-pipelines.core/Runtime/UnifiedRayTracing/Compute/ComputeRaygenShader.hlsl\"\n";
+
+        const string raytracingShaderTemplate =
+            "#define UNIFIED_RT_BACKEND_HARDWARE\n" +
+            "SHADERCODE\n" +
+            "#include_with_pragmas \"Packages/com.unity.render-pipelines.core/Runtime/UnifiedRayTracing/Hardware/HardwareRaygenShader.hlsl\"\n";
+    }
+}

--- a/Packages/com.unity.render-pipelines.core/Editor/UnifiedRayTracing/UnifiedRTShaderImporter.cs.meta
+++ b/Packages/com.unity.render-pipelines.core/Editor/UnifiedRayTracing/UnifiedRTShaderImporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 42d537a8a4089e448a99fc57a06d74a9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/com.unity.render-pipelines.core/Editor/UnifiedRayTracing/Unity.Rendering.LightTransport.Editor.asmdef
+++ b/Packages/com.unity.render-pipelines.core/Editor/UnifiedRayTracing/Unity.Rendering.LightTransport.Editor.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "Unity.Rendering.LightTransport.Editor",
+    "rootNamespace": "",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Packages/com.unity.render-pipelines.core/Editor/UnifiedRayTracing/Unity.Rendering.LightTransport.Editor.asmdef.meta
+++ b/Packages/com.unity.render-pipelines.core/Editor/UnifiedRayTracing/Unity.Rendering.LightTransport.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 70b26f7ce2ce4e4c96cbc36c7e8ddb82
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/com.unity.render-pipelines.core/Runtime/GPUDriven/InstanceCullingBatcher.cs
+++ b/Packages/com.unity.render-pipelines.core/Runtime/GPUDriven/InstanceCullingBatcher.cs
@@ -423,8 +423,6 @@ namespace UnityEngine.Rendering
                 overridenComponents |= InstanceComponentGroup.Lightmap;
             }
 
-            // Scan all materials once to retrieve whether this renderer is indirect-compatible or not (and store it in the RangeKey).
-            var supportsIndirect = true;
             for (int matIndex = 0; matIndex < materialsCount; ++matIndex)
             {
                 if (matIndex >= submeshCount)
@@ -435,7 +433,6 @@ namespace UnityEngine.Rendering
 
                 var materialIndex = rendererData.materialIndex[materialsOffset + matIndex];
                 var packedMaterialData = rendererData.packedMaterialData[materialIndex];
-                supportsIndirect &= packedMaterialData.isIndirectSupported;
             }
 
             var rangeKey = new RangeKey
@@ -446,7 +443,7 @@ namespace UnityEngine.Rendering
                 shadowCastingMode = packedRendererData.shadowCastingMode,
                 staticShadowCaster = packedRendererData.staticShadowCaster,
                 rendererPriority = rendererPriority,
-                supportsIndirect = supportsIndirect
+                supportsIndirect = true,  // For 6000.0, we always support indirect draw calls.
             };
 
             ref DrawRange drawRange = ref EditDrawRange(rangeKey);

--- a/Packages/com.unity.render-pipelines.core/Runtime/Sampling/SamplingResources.cs
+++ b/Packages/com.unity.render-pipelines.core/Runtime/Sampling/SamplingResources.cs
@@ -29,7 +29,7 @@ namespace UnityEngine.Rendering.Sampling
         {
             if ((resourceBitmask & (uint)ResourceType.BlueNoiseTextures) != 0)
             {
-                const string path = "Packages/com.unity.rendering.light-transport/Runtime/";
+                const string path = "Packages/com.unity.render-pipelines.core/Runtime/";
 
                 m_SobolScramblingTile = AssetDatabase.LoadAssetAtPath<Texture2D>(path + "Sampling/Textures/SobolBlueNoise/ScramblingTile256SPP.png");
                 m_SobolRankingTile = AssetDatabase.LoadAssetAtPath<Texture2D>(path + "Sampling/Textures/SobolBlueNoise/RankingTile256SPP.png");
@@ -66,5 +66,3 @@ namespace UnityEngine.Rendering.Sampling
 
     }
 }
-
-

--- a/Packages/com.unity.render-pipelines.core/Runtime/UnifiedRayTracing/RayTracingResources.cs
+++ b/Packages/com.unity.render-pipelines.core/Runtime/UnifiedRayTracing/RayTracingResources.cs
@@ -22,7 +22,7 @@ namespace UnityEngine.Rendering.UnifiedRayTracing
 #if UNITY_EDITOR
         public void Load()
         {
-            const string path = "Packages/com.unity.rendering.light-transport/Runtime/";
+            const string path = "Packages/com.unity.render-pipelines.core/Runtime/";
 
             geometryPoolKernels        = AssetDatabase.LoadAssetAtPath<ComputeShader>(path + "UnifiedRayTracing/Common/GeometryPool/GeometryPoolKernels.compute");
             copyBuffer                 = AssetDatabase.LoadAssetAtPath<ComputeShader>(path + "UnifiedRayTracing/Common/Utilities/CopyBuffer.compute");
@@ -40,5 +40,3 @@ namespace UnityEngine.Rendering.UnifiedRayTracing
 
     }
 }
-
-

--- a/Packages/com.unity.render-pipelines.core/package.json
+++ b/Packages/com.unity.render-pipelines.core/package.json
@@ -11,7 +11,6 @@
     "com.unity.collections": "2.4.3",
     "com.unity.modules.physics": "1.0.0",
     "com.unity.modules.terrain": "1.0.0",
-    "com.unity.modules.jsonserialize": "1.0.0",
-    "com.unity.rendering.light-transport": "1.0.1"
+    "com.unity.modules.jsonserialize": "1.0.0"
   }
 }

--- a/Packages/com.unity.render-pipelines.core/package.json
+++ b/Packages/com.unity.render-pipelines.core/package.json
@@ -11,6 +11,7 @@
     "com.unity.collections": "2.4.3",
     "com.unity.modules.physics": "1.0.0",
     "com.unity.modules.terrain": "1.0.0",
-    "com.unity.modules.jsonserialize": "1.0.0"
+    "com.unity.modules.jsonserialize": "1.0.0",
+    "com.unity.rendering.light-transport": "1.0.1"
   }
 }

--- a/Packages/com.unity.render-pipelines.universal/Editor/2D/Shadows/ShadowCaster2DEditor.cs
+++ b/Packages/com.unity.render-pipelines.universal/Editor/2D/Shadows/ShadowCaster2DEditor.cs
@@ -68,7 +68,7 @@ namespace UnityEditor.Rendering.Universal
         SerializedProperty m_ShadowShape2DProvider;
         SortingLayerDropDown m_SortingLayerDropDown;
         CastingSourceDropDown m_CastingSourceDropDown;
-       
+
 
         public void OnEnable()
         {
@@ -128,7 +128,7 @@ namespace UnityEditor.Rendering.Universal
 
             if ((ShadowCaster2D.ShadowCastingSources)m_CastingSource.intValue == ShadowCaster2D.ShadowCastingSources.ShapeEditor)
                 ShadowCaster2DInspectorGUI<ShadowCaster2DShadowCasterShapeTool>();
-            else if (EditorToolManager.IsActiveTool<ShadowCaster2DShadowCasterShapeTool>())
+            else if (Path2D.EditorToolManager.IsActiveTool<ShadowCaster2DShadowCasterShapeTool>())
                 ToolManager.RestorePreviousTool();
 
             EditorGUILayout.PropertyField(m_ShadowShape2DProvider, Styles.shadowShape2DProvider, true);


### PR DESCRIPTION
Fixed up 6000.0 compilation; 
- Restored TraceRayAndQueryHit.hlsl as referenced from origin/master
- Hard set isIndirectSupported in InstanceCullingBatcher.cs (as this branch is ONLY for 6000.0 support, the upstream changes work as of 6.1), 
- Updated constants / keyword usage in ShaderScriptableStripperTests.cs.
- Vendored `UnifiedRTShaderImporter.cs` into the project to give raytrace shaders a valid importer.

---
### Purpose of this PR
Users were getting compile errors when opening projects including the following packages:

com.unity.render-pipelines.core@git+https://github.com/Oculus-VR/Unity-Graphics.git?path=/Packages/com.unity.render-pipelines.core#6000.0/oculus-app-spacewarp
com.unity.render-pipelines.universal@git+https://github.com/Oculus-VR/Unity-Graphics.git?path=/Packages/com.unity.render-pipelines.universal#6000.0/oculus-app-spacewarp 
com.unity.shadergraph@git+https://github.com/Oculus-VR/Unity-Graphics.git?path=/Packages/com.unity.shadergraph#6000.0/oculus-app-spacewarp
The console should be clear of errors when loading these packages.

---
### Testing status
- The Graphics Repo as a project compiles locally
- Including some project-scope changes, (in the ASW6.0 [c03014335095] bookmark), the unity-appspacewarp test project builds properly with functional motion vectors

---
### Comments to reviewers
- To test, make sure that you're using git+ssh://git@github.example.com/JessAtMeta/Unity-Graphics.git#6.0/asw for Graphics package references, e.g.
```
    "com.unity.render-pipelines.core": "git+ssh://git@github.example.com/JessAtMeta/Unity-Graphics.git#6.0/asw",
    "com.unity.render-pipelines.universal": "git+ssh://git@github.example.com/JessAtMeta/Unity-Graphics.git#6.0/asw",
    "com.unity.shadergraph": "git+ssh://git@github.example.com/JessAtMeta/Unity-Graphics.git#6.0/asw",
```
Once this work is landed, these paths will need to be updated to:
```
    "com.unity.render-pipelines.core": "git+ssh://git@github.example.com/Oculus-VR/Unity-Graphics.git#6000.0/oculus-app-spacewarp",
    "com.unity.render-pipelines.universal": "git+ssh://git@github.example.com/Oculus-VR/Unity-Graphics.git#6000.0/oculus-app-spacewarp",
    "com.unity.shadergraph": "git+ssh://git@github.example.com/Oculus-VR/Unity-Graphics.git#6000.0/oculus-app-spacewarp",
```
